### PR TITLE
Make stats command interactive with runtime display

### DIFF
--- a/commands/help.c
+++ b/commands/help.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
     printf("  remove   : Remove anything, whether it is a file or folder.\n");
     printf("  runtask  : Run a proprietary .task script until CTRL+c is pressed.\n");
     printf("             Type: runtask -help for more details.\n");
-    printf("  stats    : Displays basic hardware stats.\n");
+    printf("  stats    : Displays basic hardware stats (press q to quit).\n");
     printf("  time     : Display time now in different time-zones. 'time -s' for astro\n"); 
     printf("             events.\n");
     printf("  unpack   : Unpack what has been packed, e.g. 'unpack myfolder.zip'\n");

--- a/commands/stats.c
+++ b/commands/stats.c
@@ -5,6 +5,8 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <string.h>
+#include <termios.h>
+#include <sys/select.h>
 
 // Function to get battery charge (if available)
 // Returns battery capacity (0–100) if found, or -1 if no battery is found.
@@ -50,169 +52,169 @@ int get_battery_charge(void) {
     return battery;
 }
 
-int main(void) {
-    // *** Time Retrieval and Formatting ***
-    time_t now = time(NULL);
-    if (now == (time_t)-1) {
-        perror("time");
-        return EXIT_FAILURE;
-    }
-    struct tm *local = localtime(&now);
-    if (local == NULL) {
-        perror("localtime");
-        return EXIT_FAILURE;
-    }
-    char time_str[64];
-    if (strftime(time_str, sizeof(time_str), "Time: %H:%M:%S %d-%B-%Y", local) == 0) {
-        fprintf(stderr, "strftime returned 0");
-        return EXIT_FAILURE;
-    }
-    printf("%s\n", time_str);
+static struct termios orig_termios;
 
-    // *** Free Disk Space Calculation ***
-    struct statvfs stat;
-    if (statvfs("/", &stat) != 0) {
-        perror("statvfs failed");
-        return EXIT_FAILURE;
-    }
-    unsigned long free_bytes = stat.f_bfree * stat.f_frsize;
-    double free_gb = free_bytes / (1024.0 * 1024.0 * 1024.0);
-    printf("Free Disk Space: %.1fGB\n", free_gb);
+static void reset_terminal_mode(void) {
+    tcsetattr(STDIN_FILENO, TCSANOW, &orig_termios);
+}
 
-    // *** CPU Temperature Reading ***
-    FILE *fp = fopen("/sys/class/thermal/thermal_zone0/temp", "r");
-    if (fp == NULL) {
-        perror("fopen failed for CPU temperature");
-        return EXIT_FAILURE;
-    }
-    int temp_millideg;
-    if (fscanf(fp, "%d", &temp_millideg) != 1) {
-        perror("fscanf failed for CPU temperature");
-        fclose(fp);
-        return EXIT_FAILURE;
-    }
+static void set_conio_terminal_mode(void) {
+    struct termios new_termios;
+    tcgetattr(STDIN_FILENO, &orig_termios);
+    new_termios = orig_termios;
+    new_termios.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &new_termios);
+}
+
+static int read_cpu_stats(unsigned long long *user, unsigned long long *nice,
+                          unsigned long long *system, unsigned long long *idle,
+                          unsigned long long *iowait, unsigned long long *irq,
+                          unsigned long long *softirq, unsigned long long *steal) {
+    FILE *fp = fopen("/proc/stat", "r");
+    if (!fp)
+        return -1;
+    int ret = fscanf(fp, "cpu  %llu %llu %llu %llu %llu %llu %llu %llu",
+                     user, nice, system, idle, iowait, irq, softirq, steal);
     fclose(fp);
-    double cpu_temp = temp_millideg / 1000.0;
-    printf("CPU Temp: %.0f°C\n", cpu_temp);
+    return (ret == 8) ? 0 : -1;
+}
 
-    // *** Average CPU Utilization ***
-    {
-        FILE *fp_stat;
-        unsigned long long user1, nice1, system1, idle1, iowait1, irq1, softirq1, steal1;
-        unsigned long long total1, idle_all1;
-        unsigned long long user2, nice2, system2, idle2, iowait2, irq2, softirq2, steal2;
-        unsigned long long total2, idle_all2;
+int main(void) {
+    set_conio_terminal_mode();
+    atexit(reset_terminal_mode);
 
-        fp_stat = fopen("/proc/stat", "r");
-        if (fp_stat) {
-            if (fscanf(fp_stat, "cpu  %llu %llu %llu %llu %llu %llu %llu %llu",
-                   &user1, &nice1, &system1, &idle1, &iowait1, &irq1, &softirq1, &steal1) != 8) {
-                fprintf(stderr, "Failed to parse /proc/stat\n");
-                fclose(fp_stat);
-                return EXIT_FAILURE;
+    time_t start_time = time(NULL);
+
+    unsigned long long prev_user = 0, prev_nice = 0, prev_system = 0,
+                       prev_idle = 0, prev_iowait = 0, prev_irq = 0,
+                       prev_softirq = 0, prev_steal = 0;
+    int have_prev = 0;
+
+    while (1) {
+        printf("\033[H\033[J");
+
+        time_t now = time(NULL);
+        struct tm *local = localtime(&now);
+        char time_str[64];
+        if (local && strftime(time_str, sizeof(time_str), "%H:%M:%S %d-%B-%Y", local)) {
+            printf("Time: %s\n", time_str);
+        }
+
+        double elapsed = difftime(now, start_time);
+        int hrs = (int)elapsed / 3600;
+        int mins = ((int)elapsed % 3600) / 60;
+        int secs = (int)elapsed % 60;
+        printf("Runtime: %02d:%02d:%02d\n", hrs, mins, secs);
+
+        struct statvfs stat;
+        if (statvfs("/", &stat) == 0) {
+            unsigned long free_bytes = stat.f_bfree * stat.f_frsize;
+            double free_gb = free_bytes / (1024.0 * 1024.0 * 1024.0);
+            printf("Free Disk Space: %.1fGB\n", free_gb);
+        }
+
+        FILE *fp = fopen("/sys/class/thermal/thermal_zone0/temp", "r");
+        if (fp) {
+            int temp_millideg;
+            if (fscanf(fp, "%d", &temp_millideg) == 1) {
+                double cpu_temp = temp_millideg / 1000.0;
+                printf("CPU Temp: %.0f°C\n", cpu_temp);
             }
-            fclose(fp_stat);
-            total1 = user1 + nice1 + system1 + idle1 + iowait1 + irq1 + softirq1 + steal1;
-            idle_all1 = idle1 + iowait1;
+            fclose(fp);
+        }
 
-            sleep(1); // wait 1 second for delta
-
-            fp_stat = fopen("/proc/stat", "r");
-            if (fp_stat) {
-                if (fscanf(fp_stat, "cpu  %llu %llu %llu %llu %llu %llu %llu %llu",
-                       &user2, &nice2, &system2, &idle2, &iowait2, &irq2, &softirq2, &steal2) != 8) {
-                    fprintf(stderr, "Failed to parse /proc/stat (second read)\n");
-                    fclose(fp_stat);
-                    return EXIT_FAILURE;
-                }
-                fclose(fp_stat);
-                total2 = user2 + nice2 + system2 + idle2 + iowait2 + irq2 + softirq2 + steal2;
-                idle_all2 = idle2 + iowait2;
-
-                unsigned long long delta_total = total2 - total1;
-                unsigned long long delta_idle = idle_all2 - idle_all1;
-                double cpu_usage = 0.0;
-                if (delta_total > 0) {
-                    cpu_usage = (double)(delta_total - delta_idle) * 100.0 / delta_total;
-                }
+        unsigned long long user, nice, system, idle, iowait, irq, softirq, steal;
+        if (read_cpu_stats(&user, &nice, &system, &idle, &iowait, &irq, &softirq, &steal) == 0) {
+            if (have_prev) {
+                unsigned long long total = user + nice + system + idle + iowait + irq + softirq + steal;
+                unsigned long long prev_total = prev_user + prev_nice + prev_system + prev_idle + prev_iowait + prev_irq + prev_softirq + prev_steal;
+                unsigned long long delta_total = total - prev_total;
+                unsigned long long delta_idle = (idle + iowait) - (prev_idle + prev_iowait);
+                double cpu_usage = delta_total ? (double)(delta_total - delta_idle) * 100.0 / delta_total : 0.0;
                 printf("CPU Average Utilization: %.1f%%\n", cpu_usage);
             } else {
-                perror("fopen failed for /proc/stat (second read)");
+                printf("CPU Average Utilization: N/A\n");
+                have_prev = 1;
             }
-        } else {
-            perror("fopen failed for /proc/stat (first read)");
+            prev_user = user; prev_nice = nice; prev_system = system;
+            prev_idle = idle; prev_iowait = iowait; prev_irq = irq;
+            prev_softirq = softirq; prev_steal = steal;
         }
-    }
 
-    // *** System Uptime ***
-    fp = fopen("/proc/uptime", "r");
-    if (fp != NULL) {
-        double uptime_seconds;
-        if (fscanf(fp, "%lf", &uptime_seconds) == 1) {
-            int days = (int)uptime_seconds / (24 * 3600);
-            int hours = ((int)uptime_seconds % (24 * 3600)) / 3600;
-            int minutes = (((int)uptime_seconds % 3600)) / 60;
-            int seconds = (int)uptime_seconds % 60;
-            
-            printf("Uptime: ");
-            int printed = 0;
-            if (days > 0) {
-                printf("%d %s", days, (days == 1 ? "day" : "days"));
-                printed = 1;
-            }
-            if (hours > 0) {
+        fp = fopen("/proc/uptime", "r");
+        if (fp) {
+            double uptime_seconds;
+            if (fscanf(fp, "%lf", &uptime_seconds) == 1) {
+                int days = (int)uptime_seconds / (24 * 3600);
+                int hours = ((int)uptime_seconds % (24 * 3600)) / 3600;
+                int minutes = (((int)uptime_seconds % 3600)) / 60;
+                int seconds = (int)uptime_seconds % 60;
+                printf("Uptime: ");
+                int printed = 0;
+                if (days > 0) {
+                    printf("%d %s", days, (days == 1 ? "day" : "days"));
+                    printed = 1;
+                }
+                if (hours > 0) {
+                    if (printed)
+                        printf(" ");
+                    printf("%d %s", hours, (hours == 1 ? "hour" : "hours"));
+                    printed = 1;
+                }
+                if (minutes > 0) {
+                    if (printed)
+                        printf(" ");
+                    printf("%d %s", minutes, (minutes == 1 ? "minute" : "minutes"));
+                    printed = 1;
+                }
                 if (printed)
-                    printf(" ");
-                printf("%d %s", hours, (hours == 1 ? "hour" : "hours"));
-                printed = 1;
+                    printf(" and ");
+                printf("%d %s\n", seconds, (seconds == 1 ? "second" : "seconds"));
             }
-            if (minutes > 0) {
-                if (printed)
-                    printf(" ");
-                printf("%d %s", minutes, (minutes == 1 ? "minute" : "minutes"));
-                printed = 1;
+            fclose(fp);
+        }
+
+        fp = fopen("/proc/meminfo", "r");
+        if (fp) {
+            char line[256];
+            unsigned long memTotal = 0, memAvailable = 0;
+            while (fgets(line, sizeof(line), fp)) {
+                if (sscanf(line, "MemTotal: %lu kB", &memTotal) == 1)
+                    continue;
+                if (sscanf(line, "MemAvailable: %lu kB", &memAvailable) == 1)
+                    continue;
             }
-            if (printed)
-                printf(" and ");
-            printf("%d %s\n", seconds, (seconds == 1 ? "second" : "seconds"));
-        } else {
-            fprintf(stderr, "Error reading uptime\n");
+            fclose(fp);
+            if (memTotal > 0) {
+                double totalMB = memTotal / 1024.0;
+                double usedMB = (memTotal - memAvailable) / 1024.0;
+                double usedPercent = ((memTotal - memAvailable) * 100.0) / memTotal;
+                printf("Memory Usage: %.1fMB used / %.1fMB total (%.1f%%)\n", usedMB, totalMB, usedPercent);
+            }
         }
-        fclose(fp);
-    } else {
-        perror("fopen failed for /proc/uptime");
-    }
 
-    // *** Memory Usage ***
-    fp = fopen("/proc/meminfo", "r");
-    if (fp != NULL) {
-        char line[256];
-        unsigned long memTotal = 0, memAvailable = 0;
-        while (fgets(line, sizeof(line), fp)) {
-            if (sscanf(line, "MemTotal: %lu kB", &memTotal) == 1)
-                continue;
-            if (sscanf(line, "MemAvailable: %lu kB", &memAvailable) == 1)
-                continue;
-        }
-        fclose(fp);
-        if (memTotal > 0) {
-            double totalMB = memTotal / 1024.0;
-            double usedMB = (memTotal - memAvailable) / 1024.0;
-            double usedPercent = ((memTotal - memAvailable) * 100.0) / memTotal;
-            printf("Memory Usage: %.1fMB used / %.1fMB total (%.1f%%)\n", usedMB, totalMB, usedPercent);
+        int battery = get_battery_charge();
+        if (battery >= 0) {
+            printf("Battery Charge: %d%%\n", battery);
         } else {
-            fprintf(stderr, "Failed to read MemTotal from /proc/meminfo\n");
+            printf("Battery Charge: N/A\n");
         }
-    } else {
-        perror("fopen failed for /proc/meminfo");
-    }
 
-    // *** Battery Charge Level ***
-    int battery = get_battery_charge();
-    if (battery >= 0) {
-        printf("Battery Charge: %d%%\n", battery);
-    } else {
-        printf("Battery Charge: N/A\n");
+        printf("Press 'q' to quit.\n");
+        fflush(stdout);
+
+        fd_set set;
+        FD_ZERO(&set);
+        FD_SET(STDIN_FILENO, &set);
+        struct timeval tv;
+        tv.tv_sec = 1;
+        tv.tv_usec = 0;
+        int rv = select(STDIN_FILENO + 1, &set, NULL, NULL, &tv);
+        if (rv > 0) {
+            char ch;
+            if (read(STDIN_FILENO, &ch, 1) > 0 && (ch == 'q' || ch == 'Q'))
+                break;
+        }
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary
- Run `stats` in a loop to show live hardware metrics and elapsed runtime
- Exit `stats` when the user presses `q`
- Update help text to mention interactive quit option

## Testing
- `make commands/stats commands/help`
- `printf 'q' | ./commands/stats`


------
https://chatgpt.com/codex/tasks/task_e_68a4d3f638388327b3163295c4cc5919