### PR TITLE
Support variable expansion in runtask RUN arguments

### DIFF
--- a/apps/runtask.c
+++ b/apps/runtask.c
@@ -800,6 +800,33 @@ static void free_argv(char **argv) {
     free(argv);
 }
 
+static void expand_argv_variables(char **argv, int argc, int line, int debug) {
+    if (!argv) {
+        return;
+    }
+    for (int i = 0; i < argc; ++i) {
+        char *token = argv[i];
+        if (!token || token[0] != '$') {
+            continue;
+        }
+        char name[64];
+        if (!parse_variable_name_token(token, name, sizeof(name))) {
+            if (debug) {
+                fprintf(stderr, "RUN: invalid variable reference '%s' at line %d\n", token, line);
+            }
+            continue;
+        }
+        Variable *var = find_variable(name, false);
+        Value value = variable_to_value(var);
+        char *replacement = value_to_string(&value);
+        if (!replacement) {
+            replacement = xstrdup("");
+        }
+        free(argv[i]);
+        argv[i] = replacement;
+    }
+}
+
 /* Resolve executable path:
    - If argv0 contains '/', use as-is.
    - Else try "apps/argv0", then "commands/argv0", then "utilities/argv0".
@@ -1402,6 +1429,8 @@ int main(int argc, char *argv[]) {
                     continue;
                 }
             }
+
+            expand_argv_variables(argv_heap, argcnt, script[pc].source_line, debug);
 
             // Resolve executable path
             char resolved[PATH_MAX];


### PR DESCRIPTION
## Summary
- allow the runtask RUN command to replace $VARIABLE arguments with their current values before execution
- keep variable tokens intact for TO capture while still expanding them for the launched process

## Testing
- `gcc -std=c11 -Wall -Wextra -Werror -Wpedantic -c apps/runtask.c -o /tmp/runtask.o`
- `make apps/runtask` *(fails: missing system library libasound)*

------
https://chatgpt.com/codex/tasks/task_e_68dec639aa9c8327b0bcf289923effc2