### PR TITLE
Reset cached background colors when clearing screen

### DIFF
--- a/apps/cls.c
+++ b/apps/cls.c
@@ -13,6 +13,8 @@
 
 #define _POSIX_C_SOURCE 200112L  // Enable POSIX.1-2001 features
 
+#include "../lib/termbg.h"
+
 #include <stdio.h>
 #include <unistd.h>     // for STDOUT_FILENO
 #include <stdlib.h>
@@ -71,6 +73,8 @@ int main(void)
     /* Optionally, move the cursor to home position */
     printf("\033[H");
     fflush(stdout);
+
+    termbg_clear();
 
     return 0;
 }

--- a/lib/termbg.c
+++ b/lib/termbg.c
@@ -242,6 +242,13 @@ int termbg_save(void) {
     return 0;
 }
 
+void termbg_clear(void) {
+    const char *path = state_path();
+    if (path != NULL && path[0] != '\0')
+        unlink(path);
+    termbg_shutdown();
+}
+
 void termbg_shutdown(void) {
     free(g_entries);
     g_entries = NULL;

--- a/lib/termbg.h
+++ b/lib/termbg.h
@@ -5,5 +5,6 @@ int termbg_get(int x, int y, int *color_out);
 void termbg_set(int x, int y, int color);
 int termbg_save(void);
 void termbg_shutdown(void);
+void termbg_clear(void);
 
 #endif /* TERM_BG_H */


### PR DESCRIPTION
## Summary
- add a reusable helper to clear cached terminal background colours
- invoke the helper from the cls app so clearing the screen also clears cached backgrounds

## Testing
- `make apps/cls` *(fails: /usr/bin/ld: cannot find -lasound)*

------
https://chatgpt.com/codex/tasks/task_e_68f366aa5ffc8327bd7f2b55b7d6c429