### PR TITLE
Clear scrollback after cls animation

### DIFF
--- a/apps/cls.c
+++ b/apps/cls.c
@@ -67,10 +67,13 @@ int main(void)
         }
     }
 
+    /* Clear the scrollback buffer so previous history is removed as well. */
+    printf("\033[3J");
+
     /* Restore the cursor visibility */
     printf("\033[?25h");
 
-    /* Optionally, move the cursor to home position */
+    /* Move the cursor to home position */
     printf("\033[H");
     fflush(stdout);
 


### PR DESCRIPTION
## Summary
- send the ANSI scrollback clear escape sequence after the cls animation to remove history
- keep the cursor restore and home positioning behaviour unchanged

## Testing
- make apps/cls *(fails: linker cannot find -lasound in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f36bba91f48327b4477f12661be83b