### PR TITLE
Add _VERSION command to print git commit count

### DIFF
--- a/commands/_VERSION.c
+++ b/commands/_VERSION.c
@@ -1,0 +1,54 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static int is_only_whitespace(const char *s) {
+    if (!s)
+        return 1;
+
+    while (*s != '\0') {
+        if (!isspace((unsigned char)*s))
+            return 0;
+        ++s;
+    }
+
+    return 1;
+}
+
+int main(void) {
+    long long commit_count = 0;
+    int have_value = 0;
+    FILE *pipe = popen("git rev-list --count HEAD 2>/dev/null", "r");
+
+    if (pipe != NULL) {
+        char buffer[128];
+
+        if (fgets(buffer, sizeof(buffer), pipe) != NULL) {
+            char *endptr = NULL;
+
+            errno = 0;
+            long long value = strtoll(buffer, &endptr, 10);
+
+            if (errno == 0 && endptr != buffer) {
+                if (endptr != NULL && *endptr != '\0' && !is_only_whitespace(endptr)) {
+                    have_value = 0;
+                } else if (value >= 0) {
+                    commit_count = value;
+                    have_value = 1;
+                }
+            }
+        }
+
+        pclose(pipe);
+    }
+
+    if (!have_value)
+        commit_count = 0;
+
+    printf("%lld\n", commit_count);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add the `_VERSION` command that retrieves the repository commit count via `git`
- default the output to zero when the commit count cannot be determined

## Testing
- make commands/_VERSION

------
https://chatgpt.com/codex/tasks/task_e_68f36e00e8208327b79b86744a5e34c7