### PR TITLE
Add _DISPLAY command for displaying images

### DIFF
--- a/commands/_DISPLAY.c
+++ b/commands/_DISPLAY.c
@@ -1,0 +1,99 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../lib/libimage.h"
+#include "../lib/termbg.h"
+
+static int parse_int(const char *value, const char *name, int *out) {
+    char *endptr = NULL;
+    errno = 0;
+    long parsed = strtol(value, &endptr, 10);
+
+    if (errno != 0 || endptr == value || *endptr != '\0') {
+        fprintf(stderr, "_DISPLAY: invalid integer for %s: '%s'\n", name, value);
+        return -1;
+    }
+
+    if (parsed < 0 || parsed > INT_MAX) {
+        fprintf(stderr, "_DISPLAY: integer out of range for %s: '%s'\n", name, value);
+        return -1;
+    }
+
+    *out = (int)parsed;
+    return 0;
+}
+
+static void print_usage(void) {
+    fprintf(stderr, "Usage: _DISPLAY -x <col> -y <row> -file <path>\n");
+}
+
+int main(int argc, char *argv[]) {
+    int x = 0;
+    int y = 0;
+    int have_x = 0;
+    int have_y = 0;
+    const char *file = NULL;
+
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "-x") == 0) {
+            if (++i >= argc) {
+                fprintf(stderr, "_DISPLAY: missing value for -x\n");
+                print_usage();
+                return EXIT_FAILURE;
+            }
+            if (parse_int(argv[i], "-x", &x) != 0) {
+                return EXIT_FAILURE;
+            }
+            have_x = 1;
+        } else if (strcmp(argv[i], "-y") == 0) {
+            if (++i >= argc) {
+                fprintf(stderr, "_DISPLAY: missing value for -y\n");
+                print_usage();
+                return EXIT_FAILURE;
+            }
+            if (parse_int(argv[i], "-y", &y) != 0) {
+                return EXIT_FAILURE;
+            }
+            have_y = 1;
+        } else if (strcmp(argv[i], "-file") == 0) {
+            if (++i >= argc) {
+                fprintf(stderr, "_DISPLAY: missing value for -file\n");
+                print_usage();
+                return EXIT_FAILURE;
+            }
+            file = argv[i];
+        } else {
+            fprintf(stderr, "_DISPLAY: unknown argument '%s'\n", argv[i]);
+            print_usage();
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (!have_x || !have_y || file == NULL) {
+        fprintf(stderr, "_DISPLAY: missing required arguments\n");
+        print_usage();
+        return EXIT_FAILURE;
+    }
+
+    LibImageResult result = libimage_render_file_at(file, x, y);
+    if (result == LIBIMAGE_SUCCESS) {
+        termbg_save();
+        termbg_shutdown();
+        return EXIT_SUCCESS;
+    }
+
+    termbg_save();
+    termbg_shutdown();
+
+    const char *message = libimage_last_error();
+    if (message != NULL && message[0] != '\0') {
+        fprintf(stderr, "_DISPLAY: %s\n", message);
+    } else {
+        fprintf(stderr, "_DISPLAY: failed to render image\n");
+    }
+
+    return EXIT_FAILURE;
+}

--- a/lib/libimage.c
+++ b/lib/libimage.c
@@ -258,8 +258,18 @@ static void render_pixels_at(const Pixel *pixels, int width, int height, int ori
         for (int x = 0; x < width; ++x) {
             const Pixel *p = &pixels[(size_t)y * (size_t)width + (size_t)x];
             if (p->a < 16) {
-                fputs("\x1b[49m\x1b[39m ", stdout);
-                termbg_set(origin_x + x, origin_y + y, -1);
+                int bg_color = -1;
+                if (termbg_get(origin_x + x, origin_y + y, &bg_color) != 0 && bg_color >= 0) {
+                    char seq[32];
+                    int len = snprintf(seq, sizeof(seq), "\x1b[48;5;%dm", bg_color);
+                    if (len > 0) {
+                        fwrite(seq, 1, (size_t)len, stdout);
+                    }
+                    fputs("\x1b[39m ", stdout);
+                    fputs("\x1b[49m", stdout);
+                } else {
+                    fputs("\x1b[49m\x1b[39m ", stdout);
+                }
                 continue;
             }
             int palette_index = best_palette_match(p->r, p->g, p->b);


### PR DESCRIPTION
## Summary
- add a new _DISPLAY command that renders images at specified coordinates
- ensure PNG transparency respects existing terminal background colors when drawing

## Testing
- make *(fails: /usr/bin/ld: cannot find -lasound)*

------
https://chatgpt.com/codex/tasks/task_e_68f3f343c8948327bbb6f83299eaa00d