### PR TITLE
Add output redirection support to shell commands

### DIFF
--- a/commandparser.h
+++ b/commandparser.h
@@ -23,6 +23,8 @@ typedef struct {
     char *options[MAX_OPTIONS];
     int param_count;
     int opt_count;
+    char *redirect_path;
+    int redirect_append;
 } CommandStruct;
 
 void parse_input(const char *input, CommandStruct *cmd);

--- a/main.c
+++ b/main.c
@@ -343,6 +343,10 @@ int execute_command_with_paging(CommandStruct *cmd) {
      * - The "-nopaging" flag is provided, or
      * - The command is in the realtime command list loaded from apps/ folder.
      */
+    if (cmd->redirect_path) {
+        return execute_command(cmd);
+    }
+
     if (nopaging || is_realtime_command(cmd->command)) {
         return execute_command(cmd);
     }


### PR DESCRIPTION
## Summary
- extend the command parser to detect `>`/`>>` tokens and record the target file
- update command execution to honor requested redirection and bypass paging when active
- ensure command structs clean up redirected state when freed

## Testing
- make *(fails: missing system dependency `-lasound`)*

------
https://chatgpt.com/codex/tasks/task_e_69060da83b748327a53696895a818dae