### PR TITLE
Fix _RETROPROFILE reset OSC sequences

### DIFF
--- a/commands/_RETROPROFILE.c
+++ b/commands/_RETROPROFILE.c
@@ -246,10 +246,10 @@ static void emit_palette_sequence(const RetroProfile *profile) {
 }
 
 static void reset_palette(void) {
-    emit_osc("104;");
-    emit_osc("110;");
-    emit_osc("111;");
-    emit_osc("112;");
+    emit_osc("104");
+    emit_osc("110");
+    emit_osc("111");
+    emit_osc("112");
     fflush(stdout);
     fprintf(stderr, "Requested terminal palette/default reset via OSC 104/110/111/112.\n");
 }


### PR DESCRIPTION
## Summary
- ensure the reset subcommand emits OSC 104/110/111/112 without empty parameters so terminals restore defaults

## Testing
- make commands/_RETROPROFILE *(fails: /usr/bin/ld: cannot find -lasound)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a7a2f1808327bac537cc8a87a0f6)