### PR TITLE
Set terminal app default window size to 320x200

### DIFF
--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -639,9 +639,9 @@ int main(int argc, char **argv) {
     SDL_Window *window = SDL_CreateWindow("BUDOSTACK Terminal",
                                           SDL_WINDOWPOS_UNDEFINED,
                                           SDL_WINDOWPOS_UNDEFINED,
-                                          1280,
-                                          720,
-                                          SDL_WINDOW_FULLSCREEN_DESKTOP | SDL_WINDOW_RESIZABLE);
+                                          320,
+                                          200,
+                                          SDL_WINDOW_RESIZABLE);
     if (!window) {
         fprintf(stderr, "SDL_CreateWindow failed: %s\n", SDL_GetError());
         SDL_Quit();


### PR DESCRIPTION
## Summary
- set the terminal window default resolution to 320x200 and remove the fullscreen flag so it starts in a classic DOS sized window

## Testing
- make apps/terminal

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163165ca048327b63c19dd97e35eda)