### PR TITLE
Add terminal margin OSC command

### DIFF
--- a/commands/_TERM_MARGIN.c
+++ b/commands/_TERM_MARGIN.c
@@ -1,0 +1,44 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void print_usage(void) {
+    fprintf(stderr, "Usage: _TERM_MARGIN <pixels>\n");
+    fprintf(stderr, "  Sets the terminal render margin in pixels.\n");
+}
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        print_usage();
+        return EXIT_FAILURE;
+    }
+
+    char *endptr = NULL;
+    errno = 0;
+    long value = strtol(argv[1], &endptr, 10);
+    if (errno != 0 || !endptr || *endptr != '\0') {
+        fprintf(stderr, "_TERM_MARGIN: invalid pixel value '%s'\n", argv[1]);
+        print_usage();
+        return EXIT_FAILURE;
+    }
+
+    if (value < 0 || value > INT_MAX) {
+        fprintf(stderr, "_TERM_MARGIN: pixel value must be between 0 and %d.\n", INT_MAX);
+        return EXIT_FAILURE;
+    }
+
+    if (printf("\x1b]777;margin=%ld\a", value) < 0) {
+        perror("_TERM_MARGIN: printf");
+        return EXIT_FAILURE;
+    }
+
+    if (fflush(stdout) != 0) {
+        perror("_TERM_MARGIN: fflush");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- add the _TERM_MARGIN command to configure the terminal margin via OSC 777
- extend the SDL terminal to honor a configurable pixel margin when sizing and rendering

## Testing
- make *(fails: linker cannot find -lasound in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c4b4fda88327af03e71044b3b581)