### PR TITLE
Add mouse selection and clipboard support to terminal

### DIFF
--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -4615,8 +4615,6 @@ int main(int argc, char **argv) {
                     continue;
                 }
 
-                terminal_selection_clear(&terminal_selection_state);
-
                 if ((mod & KMOD_CTRL) != 0) {
                     if (sym >= 0 && sym <= 127) {
                         int ascii = (int)sym;
@@ -4913,6 +4911,7 @@ int main(int argc, char **argv) {
                 }
 
                 if (handled) {
+                    terminal_selection_clear(&terminal_selection_state);
                     cursor_phase_visible = 1;
                     cursor_last_toggle = SDL_GetTicks();
                     continue;


### PR DESCRIPTION
## Summary
- add selection data structures, viewport helpers, and clipboard utilities for the SDL terminal
- allow left-drag text selection with highlighted rendering plus Ctrl+Shift+C/V shortcuts for copy and paste
- trim trailing spaces when copying and clear selections when new keyboard/text events arrive

## Testing
- `make apps/terminal` *(fails: linker cannot find -lasound on the container image)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e1192cb08327992934b72c8527d2)