### PR TITLE
Improve UTF-8 handling in command input

### DIFF
--- a/main.c
+++ b/main.c
@@ -16,6 +16,7 @@
 #include <sys/select.h> // For select()
 #include <dirent.h>     // For directory handling
 #include <sys/stat.h>   // For stat()
+#include <locale.h>
 
 #include "commandparser.h"
 #include "input.h"      // Include the input handling header
@@ -518,6 +519,8 @@ static void run_shell_command(const char *shell_command) {
 int main(int argc, char *argv[]) {
     char *input;
     CommandStruct cmd;
+
+    setlocale(LC_CTYPE, "");
 
     /* 
      * Ignore SIGINT in the shell so that CTRL+C does not quit BUDOSTACK.


### PR DESCRIPTION
## Summary
- add locale-aware helpers so backspace removes an entire UTF-8 code point at once and redraws the tail using its display width
- initialize the process locale to enable the new UTF-8 handling logic

## Testing
- make


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691989f9e1788327a39b935a6708f70d)