### PR TITLE
Improve terminal Unicode input handling

### DIFF
--- a/main.c
+++ b/main.c
@@ -520,7 +520,9 @@ int main(int argc, char *argv[]) {
     char *input;
     CommandStruct cmd;
 
-    setlocale(LC_CTYPE, "");
+    if (!setlocale(LC_ALL, "")) {
+        fprintf(stderr, "Warning: failed to configure locale; Unicode I/O may be limited.\n");
+    }
 
     /* 
      * Ignore SIGINT in the shell so that CTRL+C does not quit BUDOSTACK.


### PR DESCRIPTION
## Summary
- initialize the shell with `LC_ALL` so every locale category honors the runtime environment and UTF-8 aware code works reliably
- overhaul `read_input` so it treats UTF-8 sequences as atomic units, including cursor movement, history navigation, and auto-complete redraw logic
- add helpers to compute display-width deltas and to move the on-screen cursor by glyph columns, ensuring multi-byte characters are echoed and edited correctly

## Testing
- `gcc -std=c11 -Wall -Wextra -Werror -Wpedantic -c main.c -o /tmp/main.o`
- `gcc -std=c11 -Wall -Wextra -Werror -Wpedantic -c input.c -o /tmp/input.o`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69199f1d862c8327aa5ffa9b841d124a)