### PR TITLE
Fix shell input wrapping

### DIFF
--- a/input.c
+++ b/input.c
@@ -416,12 +416,16 @@ static void list_filename_matches(const char *dir, const char *prefix) {
 }
 
 static void redraw_from_cursor(const char *buffer, size_t cursor, int clear_extra_space) {
-    printf("\033[s");
-    printf("%s", buffer + cursor);
+    const char *tail = buffer + cursor;
+    int tail_width = utf8_string_display_width(tail);
+    printf("%s", tail);
     if (clear_extra_space) {
         printf(" ");
     }
-    printf("\033[u");
+    int move_back = tail_width + (clear_extra_space ? 1 : 0);
+    for (int i = 0; i < move_back; i++) {
+        printf("\b");
+    }
     fflush(stdout);
 }
 


### PR DESCRIPTION
## Summary
- rework the interactive input redraw helper so it no longer relies on cursor save/restore
- use backspace-aware redrawing to allow the terminal to handle line wrapping naturally when editing long commands

## Testing
- make clean all

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cca0f637c83278fafdd5609408041)