### PR TITLE
Fix terminal cursor wrap after final column output

### DIFF
--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -3558,6 +3558,13 @@ static void terminal_put_char(struct terminal_buffer *buffer, uint32_t ch) {
         struct terminal_cell *cell = &buffer->cells[buffer->cursor_row * buffer->columns + buffer->cursor_column];
         terminal_cell_apply_current(buffer, cell, ch);
         buffer->cursor_column++;
+        if (buffer->cursor_column >= buffer->columns) {
+            buffer->cursor_column = 0u;
+            buffer->cursor_row++;
+            if (buffer->cursor_row >= buffer->rows) {
+                terminal_buffer_scroll(buffer);
+            }
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary
- wrap the terminal cursor to the next line immediately after writing a character in the last column
- trigger scrolling when wrapping past the bottom row so the cursor stays in range

## Testing
- make clean all


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2409e7388327ad464610d98d3b54)