### PR TITLE
Configure terminal pty for standard line handling

### DIFF
--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -4647,7 +4647,14 @@ static void terminal_configure_pty_defaults(int fd) {
         return;
     }
 
-    tio.c_lflag |= (ICANON | ECHO | ECHOE | ECHOK | ECHOCTL | ECHOKE | IEXTEN | ISIG);
+    tcflag_t lflag_add = (ICANON | ECHO | ECHOE | ECHOK | IEXTEN | ISIG);
+#ifdef ECHOCTL
+    lflag_add |= ECHOCTL;
+#endif
+#ifdef ECHOKE
+    lflag_add |= ECHOKE;
+#endif
+    tio.c_lflag |= lflag_add;
     tio.c_lflag &= (tcflag_t)~(TOSTOP | NOFLSH);
 
     tio.c_iflag |= (ICRNL | IXON);


### PR DESCRIPTION
## Summary
- add default pseudo-terminal configuration to mimic standard Linux line discipline settings
- apply the configuration when launching the budostack child so command line editing and wrapping behave normally

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2634f0e4832792ee70b09697971c)