### PR TITLE
Fix inline command editing redraw

### DIFF
--- a/input.c
+++ b/input.c
@@ -424,8 +424,6 @@ static void redraw_from_cursor(const char *buffer, size_t cursor, int clear_extr
     if (clear_extra_space) {
         printf(" ");
     }
-    /* Clear everything from here to the end of the screen to handle wrapped lines. */
-    printf("\033[J");
     printf("\033[u"); /* Restore cursor position */
     fflush(stdout);
 }


### PR DESCRIPTION
## Summary
- preserve the command line tail when editing by repainting from the cursor without erasing on-screen text

## Testing
- make clean all

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2cdcce90832796778c0a644c83ae)