### PR TITLE
Improve interactive command editing

### DIFF
--- a/commandparser.h
+++ b/commandparser.h
@@ -13,7 +13,7 @@
 #ifndef COMMANDPARSER_H
 #define COMMANDPARSER_H
 
-#define INPUT_SIZE 256
+#define INPUT_SIZE 1024
 #define MAX_PARAMETERS 10
 #define MAX_OPTIONS 10
 

--- a/input.c
+++ b/input.c
@@ -153,6 +153,18 @@ char* read_input(void) {
                         cursor = prev;
                     }
                     continue;
+                } else if (next2 == '3') { /* Delete key sequence: ESC [ 3 ~ */
+                    int next3 = getchar();
+                    if (next3 == '~') {
+                        if (cursor < pos) {
+                            size_t next = utf8_next_char_start(buffer, cursor, pos);
+                            size_t removed_bytes = next - cursor;
+                            memmove(buffer + cursor, buffer + next, pos - next + 1);
+                            pos -= removed_bytes;
+                            redraw_from_cursor(buffer, cursor, 1);
+                        }
+                        continue;
+                    }
                 }
                 /* Ignore other escape sequences */
             }


### PR DESCRIPTION
## Summary
- align the command parser buffer size with the interactive input buffer to avoid truncating edited commands
- handle the Delete key in the raw input loop so inline edits shift text without wiping the remainder of the line

## Testing
- make clean all

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e34abb368832795b170639e3a2892)