### PR TITLE
terminal: avoid Enter-overwrite of multiline input by deferring autowrap

### DIFF
--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -1182,6 +1182,7 @@ struct terminal_buffer {
     uint32_t palette[256];
     uint32_t last_emitted;
     int last_emitted_valid;
+    int wrap_pending;
 };
 
 static void terminal_apply_scale(struct terminal_buffer *buffer, int scale);
@@ -4260,6 +4261,7 @@ static int terminal_buffer_init(struct terminal_buffer *buffer, size_t columns, 
     buffer->scroll_offset = 0u;
     buffer->last_emitted = 0u;
     buffer->last_emitted_valid = 0;
+    buffer->wrap_pending = 0;
 
     if (columns == 0u || rows == 0u) {
         buffer->cells = NULL;
@@ -4435,6 +4437,7 @@ static void terminal_buffer_free(struct terminal_buffer *buffer) {
     buffer->history_rows = 0u;
     buffer->history_start = 0u;
     buffer->scroll_offset = 0u;
+    buffer->wrap_pending = 0;
 }
 
 static int terminal_prepare_alternate_buffer(const struct terminal_buffer *source) {
@@ -4641,6 +4644,7 @@ static void terminal_buffer_index(struct terminal_buffer *buffer) {
     if (!buffer || buffer->rows == 0u) {
         return;
     }
+    buffer->wrap_pending = 0;
 
     if (buffer->cursor_row >= buffer->rows) {
         buffer->cursor_row = buffer->rows - 1u;
@@ -4664,6 +4668,7 @@ static void terminal_buffer_reverse_index(struct terminal_buffer *buffer) {
     if (!buffer || buffer->rows == 0u) {
         return;
     }
+    buffer->wrap_pending = 0;
 
     if (buffer->cursor_row >= buffer->rows) {
         buffer->cursor_row = buffer->rows - 1u;
@@ -4713,6 +4718,7 @@ static void terminal_buffer_set_cursor(struct terminal_buffer *buffer, size_t co
     }
     buffer->cursor_column = column;
     buffer->cursor_row = row;
+    buffer->wrap_pending = 0;
 }
 
 static void terminal_buffer_move_relative(struct terminal_buffer *buffer, int column_delta, int row_delta) {
@@ -4735,6 +4741,7 @@ static void terminal_buffer_move_relative(struct terminal_buffer *buffer, int co
     }
     buffer->cursor_column = (size_t)new_column;
     buffer->cursor_row = (size_t)new_row;
+    buffer->wrap_pending = 0;
 }
 
 static void terminal_buffer_clear_line_segment(struct terminal_buffer *buffer,
@@ -5046,9 +5053,11 @@ static void terminal_put_char(struct terminal_buffer *buffer, uint32_t ch) {
     switch (ch) {
     case '\r':
         buffer->cursor_column = 0u;
+        buffer->wrap_pending = 0;
         return;
     case '\n':
         buffer->cursor_column = 0u;
+        buffer->wrap_pending = 0;
         terminal_buffer_index(buffer);
         return;
     case '\t': {
@@ -5092,6 +5101,7 @@ static void terminal_put_char(struct terminal_buffer *buffer, uint32_t ch) {
          * If we cleared the cell here, every cursor move left would
          * visually delete characters, which is what we are seeing now.
          */
+        buffer->wrap_pending = 0;
         if (buffer->cursor_column > 0u) {
             buffer->cursor_column--;
         } else if (buffer->cursor_row > 0u) {
@@ -5102,6 +5112,11 @@ static void terminal_put_char(struct terminal_buffer *buffer, uint32_t ch) {
     default:
         if (ch < 32u && ch != '\t') {
             return;
+        }
+        if (buffer->wrap_pending) {
+            buffer->cursor_column = 0u;
+            terminal_buffer_index(buffer);
+            buffer->wrap_pending = 0;
         }
         if (buffer->cursor_row >= buffer->rows) {
             terminal_buffer_index(buffer);
@@ -5127,7 +5142,11 @@ static void terminal_put_char(struct terminal_buffer *buffer, uint32_t ch) {
         terminal_cell_apply_current(buffer, cell, ch);
         buffer->last_emitted = ch;
         buffer->last_emitted_valid = 1;
-        buffer->cursor_column++;
+        if (buffer->cursor_column + 1u >= buffer->columns) {
+            buffer->wrap_pending = 1;
+        } else {
+            buffer->cursor_column++;
+        }
         return;
     }
 


### PR DESCRIPTION
### Motivation
- Terminal input with wrapped prompt lines could be overwritten when pressing ENTER because the buffer advanced past the right edge eagerly.
- The change models deferred autowrap behavior (as seen in terminals like Konsole) so wrapped lines remain visually intact until the wrap is actually consumed.
- This aligns the terminal's multiline editing/display behavior with the earlier multiline display fix and prevents Enter-triggered output from destroying the edited multiline command text.

### Description
- Added a `wrap_pending` flag to `struct terminal_buffer` to represent a pending autowrap at the right edge and stored it in `apps/terminal.c`.
- Initialized and cleared `wrap_pending` during buffer lifecycle (`terminal_buffer_init` / `terminal_buffer_free`) and when cursor is explicitly set or moved (`terminal_buffer_set_cursor`, `terminal_buffer_move_relative`).
- Cleared `wrap_pending` on control actions that reposition the cursor (`CR`, `LF`, backspace, `index`/`reverse_index`) so stale wrap state cannot cause visual corruption.
- Changed printable-character handling in `terminal_put_char()` so a pending wrap is consumed before placing the next glyph and, instead of advancing past the last column, sets `wrap_pending` when the next write would cross the right edge.

### Testing
- Ran `make clean all` from the repository root as required by contributor notes, and the build completed successfully with strict flags (`-Wall -Wextra -Werror -Wpedantic`).
- No compiler warnings or errors were reported during the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2ac7ca29483279c83ea316dcab7f0)