### PR TITLE
Optimize terminal shader pacing for static CRT passes

### DIFF
--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -3849,6 +3849,21 @@ static int terminal_shaders_active(void) {
     return terminal_shaders_enabled && terminal_gl_shader_count > 0u;
 }
 
+static int terminal_shaders_require_animation(void) {
+    if (!terminal_shaders_active()) {
+        return 0;
+    }
+
+    for (size_t i = 0; i < terminal_gl_shader_count; i++) {
+        const struct terminal_gl_shader *shader = &terminal_gl_shaders[i];
+        if (shader->uniform_frame_count >= 0 || shader->uniform_prev_sampler >= 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
 static void terminal_print_usage(const char *progname) {
     const char *name = (progname && progname[0] != '\0') ? progname : "terminal";
     fprintf(stderr, "Usage: %s [-s shader_path]... [--fps hz] [--shader-fps hz]\n", name);
@@ -8655,7 +8670,8 @@ int main(int argc, char **argv) {
         }
 
         shader_timing_enabled = (terminal_shaders_active() &&
-                                 terminal_shader_frame_interval_ms > 0u);
+                                 terminal_shader_frame_interval_ms > 0u &&
+                                 terminal_shaders_require_animation());
         if (shader_timing_enabled) {
             Uint32 elapsed = now - terminal_shader_last_frame_tick;
             if (elapsed >= terminal_shader_frame_interval_ms) {


### PR DESCRIPTION
### Motivation
- Reduce GPU usage when running the terminal with CRT-style shader stacks that are visually static, without degrading the CRT simulation quality for shaders that require animation or history feedback.

### Description
- Add `terminal_shaders_require_animation()` to detect whether any active GL shader uses time/history inputs (checks `uniform_frame_count` and `uniform_prev_sampler`).
- Gate shader pacing by updating `shader_timing_enabled` only when `terminal_shaders_require_animation()` returns true, so static shader passes no longer trigger periodic shader frames.
- Preserve existing behavior and visual quality for animated shaders and the existing shader loading/composition paths.

### Testing
- Ran `make clean all` from the repository root and the build completed successfully with the project compiler flags (`-std=c11 -Wall -Wextra -Werror -Wpedantic`) and no compiler warnings or errors.
- The build log shows a non-fatal warning from the optional `./budo/build.sh` step about missing SDL2 development files, but the main build artifacts compiled and linked successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2ae16017483278472eb0fb2a5ee6c)