### PR TITLE
Fix C comment highlighting inside string/char literals

### DIFF
--- a/apps/edit.c
+++ b/apps/edit.c
@@ -324,10 +324,20 @@ void editorDelCharAtCursor(void);
 void editorSearch(void);
 void editorReplace(void);
 
+static int editorCharIsEscaped(const char *line, int pos) {
+    int backslash_count = 0;
+    int i = pos - 1;
+
+    while (i >= 0 && line[i] == '\\') {
+        backslash_count++;
+        i--;
+    }
+
+    return (backslash_count % 2) != 0;
+}
+
 /* --- New Function: update_syntax ---
-   Updates each line’s multi-line comment state.
-   This simple state machine (which does not consider string/char literals) scans
-   through all lines so that the highlighter can know whether a line starts in a comment.
+   Updates each line’s multi-line comment state while respecting literals.
 */
 void update_syntax(void) {
     int in_comment = 0;
@@ -342,15 +352,43 @@ void update_syntax(void) {
         E.row[i].hl_in_comment = in_comment;
         char *line = E.row[i].chars;
         int j = 0;
+        int in_string = 0;
+        int in_char = 0;
 
         while (j < E.row[i].size) {
-            if (!in_comment && j + 1 < E.row[i].size && line[j] == '/' && line[j + 1] == '*') {
-                in_comment = 1;
-                j += 2;
+            if (in_comment) {
+                if (j + 1 < E.row[i].size && line[j] == '*' && line[j + 1] == '/') {
+                    in_comment = 0;
+                    j += 2;
+                    continue;
+                }
+                j++;
                 continue;
             }
-            if (in_comment && j + 1 < E.row[i].size && line[j] == '*' && line[j + 1] == '/') {
-                in_comment = 0;
+
+            if (!in_char && line[j] == '"' && !editorCharIsEscaped(line, j)) {
+                in_string = !in_string;
+                j++;
+                continue;
+            }
+
+            if (!in_string && line[j] == '\'' && !editorCharIsEscaped(line, j)) {
+                in_char = !in_char;
+                j++;
+                continue;
+            }
+
+            if (in_string || in_char) {
+                j++;
+                continue;
+            }
+
+            if (j + 1 < E.row[i].size && line[j] == '/' && line[j + 1] == '/') {
+                break;
+            }
+
+            if (!in_comment && j + 1 < E.row[i].size && line[j] == '/' && line[j + 1] == '*') {
+                in_comment = 1;
                 j += 2;
                 continue;
             }

--- a/lib/libedit.c
+++ b/lib/libedit.c
@@ -77,6 +77,17 @@ static size_t append_reset(char *dest, size_t pos, size_t size) {
     return pos + rl;
 }
 
+static int is_escaped_at(const char *line, size_t pos) {
+    size_t backslash_count = 0;
+
+    while (pos > 0 && line[pos - 1] == '\\') {
+        backslash_count++;
+        pos--;
+    }
+
+    return (backslash_count % 2U) != 0U;
+}
+
 int libedit_is_plain_text(const char *filename) {
     if (!filename)
         return 0;
@@ -271,6 +282,36 @@ char *highlight_c_line(const char *line, int hl_in_comment) {
                 continue;
             }
         } else {
+            /* Check for string literal start */
+            if (line[i] == '"') {
+                ri = append_color(result, ri, buf_size, COLOR_STRING_RGB);
+                result[ri++] = line[i++];  // copy starting quote
+                while (i < len) {
+                    result[ri++] = line[i];
+                    if (line[i] == '"' && !is_escaped_at(line, i)) {
+                        i++;
+                        break;
+                    }
+                    i++;
+                }
+                ri = append_reset(result, ri, buf_size);
+                continue;
+            }
+            /* Check for character literal start */
+            if (line[i] == '\'') {
+                ri = append_color(result, ri, buf_size, COLOR_STRING_RGB);
+                result[ri++] = line[i++];  // copy starting single quote
+                while (i < len) {
+                    result[ri++] = line[i];
+                    if (line[i] == '\'' && !is_escaped_at(line, i)) {
+                        i++;
+                        break;
+                    }
+                    i++;
+                }
+                ri = append_reset(result, ri, buf_size);
+                continue;
+            }
             /* Check for start of multi-line comment */
             if (i + 1 < len && line[i] == '/' && line[i + 1] == '*') {
                 ri = append_color(result, ri, buf_size, COLOR_COMMENT_RGB);
@@ -288,36 +329,6 @@ char *highlight_c_line(const char *line, int hl_in_comment) {
                 }
                 ri = append_reset(result, ri, buf_size);
                 break;
-            }
-            /* Check for string literal start */
-            if (line[i] == '"') {
-                ri = append_color(result, ri, buf_size, COLOR_STRING_RGB);
-                result[ri++] = line[i++];  // copy starting quote
-                while (i < len) {
-                    result[ri++] = line[i];
-                    if (line[i] == '"' && (i == 0 || line[i - 1] != '\\')) {
-                        i++;
-                        break;
-                    }
-                    i++;
-                }
-                ri = append_reset(result, ri, buf_size);
-                continue;
-            }
-            /* Check for character literal start */
-            if (line[i] == '\'') {
-                ri = append_color(result, ri, buf_size, COLOR_STRING_RGB);
-                result[ri++] = line[i++];  // copy starting single quote
-                while (i < len) {
-                    result[ri++] = line[i];
-                    if (line[i] == '\'' && (i == 0 || line[i - 1] != '\\')) {
-                        i++;
-                        break;
-                    }
-                    i++;
-                }
-                ri = append_reset(result, ri, buf_size);
-                continue;
             }
             /* Check for identifier (potential keyword) */
             if (is_identifier_start_char(line[i]) &&


### PR DESCRIPTION
### Motivation
- The C syntax highlighter and the editor's multi-line comment scanner treated `/*` and `//` inside string or character literals as comment markers, causing incorrect highlighting and a stuck comment state across lines.

### Description
- Added `editorCharIsEscaped` and updated `update_syntax` in `apps/edit.c` to track `in_string` and `in_char` and to ignore comment markers when inside literals.
- Added `is_escaped_at` to `lib/libedit.c` and changed `highlight_c_line` to parse string/char literals before recognizing comment markers and to use escape-aware checks for literal termination.
- Reordered comment detection in the highlighter so multi-line and single-line comment handling runs only after literal parsing to avoid false comment coloring.
- Preserved existing cross-line comment state via the `hl_in_comment` parameter while improving literal-aware scanning.

### Testing
- Ran `make clean all` from the repository root and the build completed successfully with no compiler warnings or errors.
- The `./budo/build.sh` step produced a non-fatal warning about missing SDL2 development files but did not prevent the automated build from succeeding.
- No additional automated tests are present in the repository beyond the build validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9ef8c4b08327b6e454be26066fb5)