### PR TITLE
Introduce lightweight CRT emulation and CRT mode selection for terminal

### DIFF
--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -8553,6 +8553,14 @@ int main(int argc, char **argv) {
         }
 
         int full_redraw = terminal_force_full_redraw;
+        if (terminal_crt_mode == TERMINAL_CRT_MODE_LIGHT) {
+            /*
+             * Lightweight CRT post-processing is applied on the CPU after glyph
+             * rasterization. Force a full source redraw so we always warp from a
+             * clean terminal frame and avoid stacking/cascade artifacts.
+             */
+            full_redraw = 1;
+        }
         terminal_force_full_redraw = 0;
         int frame_dirty = 0;
         int shader_timing_enabled = 0;

--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -102,6 +102,12 @@ static Uint32 terminal_shader_frame_interval_ms = 0u;
 static Uint32 terminal_render_last_frame_tick = 0u;
 static Uint32 terminal_render_frame_interval_ms = 0u;
 static int terminal_shaders_enabled = 1;
+enum terminal_crt_mode {
+    TERMINAL_CRT_MODE_DISABLE = 0,
+    TERMINAL_CRT_MODE_LIGHT = 1,
+    TERMINAL_CRT_MODE_SHADER = 2
+};
+static enum terminal_crt_mode terminal_crt_mode = TERMINAL_CRT_MODE_SHADER;
 static int terminal_vsync_enabled = 0;
 static int terminal_input_draw_requested = 0;
 static unsigned int terminal_runtime_target_fps = TERMINAL_TARGET_FPS;
@@ -3846,7 +3852,75 @@ static int terminal_enable_shaders(void) {
 }
 
 static int terminal_shaders_active(void) {
-    return terminal_shaders_enabled && terminal_gl_shader_count > 0u;
+    return terminal_crt_mode == TERMINAL_CRT_MODE_SHADER &&
+           terminal_shaders_enabled &&
+           terminal_gl_shader_count > 0u;
+}
+
+static void terminal_apply_lightweight_crt(uint8_t *framebuffer, int width, int height) {
+    if (!framebuffer || width <= 1 || height <= 1) {
+        return;
+    }
+
+    size_t pixel_count = (size_t)width * (size_t)height;
+    if (pixel_count == 0u || pixel_count > SIZE_MAX / 4u) {
+        return;
+    }
+
+    size_t byte_count = pixel_count * 4u;
+    uint8_t *source = (uint8_t *)malloc(byte_count);
+    if (!source) {
+        return;
+    }
+    memcpy(source, framebuffer, byte_count);
+
+    const float curve_strength_x = 0.085f;
+    const float curve_strength_y = 0.105f;
+    const float center_x = ((float)width - 1.0f) * 0.5f;
+    const float center_y = ((float)height - 1.0f) * 0.5f;
+    const float inv_center_x = center_x > 0.0f ? 1.0f / center_x : 0.0f;
+    const float inv_center_y = center_y > 0.0f ? 1.0f / center_y : 0.0f;
+
+    for (int y = 0; y < height; y++) {
+        float ny = ((float)y - center_y) * inv_center_y;
+        for (int x = 0; x < width; x++) {
+            float nx = ((float)x - center_x) * inv_center_x;
+            float radius2 = nx * nx + ny * ny;
+            float warp = 1.0f + radius2 * 0.35f;
+            float warped_nx = nx * (1.0f + curve_strength_x * warp);
+            float warped_ny = ny * (1.0f + curve_strength_y * warp);
+            float src_xf = center_x + warped_nx * center_x;
+            float src_yf = center_y + warped_ny * center_y;
+            int src_x = (int)src_xf;
+            int src_y = (int)src_yf;
+
+            uint8_t r = 0u;
+            uint8_t g = 0u;
+            uint8_t b = 0u;
+            uint8_t a = 255u;
+            if (src_x >= 0 && src_x < width && src_y >= 0 && src_y < height) {
+                size_t src_idx = ((size_t)src_y * (size_t)width + (size_t)src_x) * 4u;
+                r = source[src_idx + 0u];
+                g = source[src_idx + 1u];
+                b = source[src_idx + 2u];
+                a = source[src_idx + 3u];
+            }
+
+            if ((y & 1) != 0) {
+                r = (uint8_t)((unsigned int)r * 200u / 255u);
+                g = (uint8_t)((unsigned int)g * 200u / 255u);
+                b = (uint8_t)((unsigned int)b * 200u / 255u);
+            }
+
+            size_t dst_idx = ((size_t)y * (size_t)width + (size_t)x) * 4u;
+            framebuffer[dst_idx + 0u] = r;
+            framebuffer[dst_idx + 1u] = g;
+            framebuffer[dst_idx + 2u] = b;
+            framebuffer[dst_idx + 3u] = a;
+        }
+    }
+
+    free(source);
 }
 
 static int terminal_shaders_require_animation(void) {
@@ -3869,7 +3943,7 @@ static void terminal_print_usage(const char *progname) {
     fprintf(stderr, "Usage: %s [-s shader_path]... [--fps hz] [--shader-fps hz]\n", name);
     fprintf(stderr, "  --fps hz         Set render target FPS (0 disables frame pacing).\n");
     fprintf(stderr, "  --shader-fps hz  Set shader animation FPS (0 disables animation pacing).\n");
-    fprintf(stderr, "  Send OSC 777 'shader=enable|disable' via _TERM_SHADER to toggle shaders at runtime.\n");
+    fprintf(stderr, "  Send OSC 777 'shader=disable|light|shader' via _TERM_SHADER to set CRT mode at runtime.\n");
     fprintf(stderr, "  Send OSC 777 'cursor_blink=enable|disable' via _TERM_CURSOR_BLINK to toggle cursor blinking.\n");
 }
 
@@ -5582,8 +5656,8 @@ static void terminal_handle_osc_777(struct terminal_buffer *buffer, const char *
     int mouse_query_requested = 0;
     int mouse_visibility_requested = 0;
     int mouse_visibility_show = 0;
-    int shader_toggle_requested = 0;
-    int shader_enable_requested = 0;
+    int shader_mode_requested = 0;
+    enum terminal_crt_mode requested_crt_mode = terminal_crt_mode;
     int cursor_blink_toggle_requested = 0;
     int cursor_blink_enable_requested = 1;
 
@@ -5706,12 +5780,15 @@ static void terminal_handle_osc_777(struct terminal_buffer *buffer, const char *
                             resolution_requested = 1;
                         }
                     } else if (strcmp(key, "shader") == 0 && value && *value != '\0') {
-                        if (strcmp(value, "enable") == 0) {
-                            shader_toggle_requested = 1;
-                            shader_enable_requested = 1;
+                        if (strcmp(value, "shader") == 0 || strcmp(value, "enable") == 0) {
+                            shader_mode_requested = 1;
+                            requested_crt_mode = TERMINAL_CRT_MODE_SHADER;
+                        } else if (strcmp(value, "light") == 0) {
+                            shader_mode_requested = 1;
+                            requested_crt_mode = TERMINAL_CRT_MODE_LIGHT;
                         } else if (strcmp(value, "disable") == 0) {
-                            shader_toggle_requested = 1;
-                            shader_enable_requested = 0;
+                            shader_mode_requested = 1;
+                            requested_crt_mode = TERMINAL_CRT_MODE_DISABLE;
                         }
                     } else if (strcmp(key, "cursor_blink") == 0 && value && *value != '\0') {
                         if (strcmp(value, "enable") == 0) {
@@ -6080,9 +6157,11 @@ static void terminal_handle_osc_777(struct terminal_buffer *buffer, const char *
                 }
             }
 
-            if (shader_toggle_requested) {
-                if (shader_enable_requested) {
+            if (shader_mode_requested) {
+                terminal_crt_mode = requested_crt_mode;
+                if (terminal_crt_mode == TERMINAL_CRT_MODE_SHADER) {
                     if (terminal_enable_shaders() != 0) {
+                        terminal_crt_mode = TERMINAL_CRT_MODE_DISABLE;
                         fprintf(stderr, "terminal: Failed to enable shaders; remaining disabled.\n");
                     }
                 } else {
@@ -8732,6 +8811,9 @@ int main(int argc, char **argv) {
         }
 
         if (frame_dirty) {
+            if (terminal_crt_mode == TERMINAL_CRT_MODE_LIGHT) {
+                terminal_apply_lightweight_crt(framebuffer, frame_width, frame_height);
+            }
             if (terminal_upload_framebuffer(framebuffer, frame_width, frame_height) != 0) {
                 fprintf(stderr, "Failed to upload framebuffer to GPU.\n");
                 running = 0;

--- a/commands/_TERM_SHADER.c
+++ b/commands/_TERM_SHADER.c
@@ -5,8 +5,10 @@
 #include <string.h>
 
 static void print_usage(void) {
-    fprintf(stderr, "Usage: _TERM_SHADER <enable|disable>\n");
-    fprintf(stderr, "  Enables or disables terminal shader passes.\n");
+    fprintf(stderr, "Usage: _TERM_SHADER <disable|light|shader>\n");
+    fprintf(stderr, "  disable : disable CRT post-processing effects.\n");
+    fprintf(stderr, "  light   : enable lightweight CPU CRT simulation (curvature + scanlines).\n");
+    fprintf(stderr, "  shader  : enable full shader stack CRT processing.\n");
 }
 
 int main(int argc, char **argv) {
@@ -16,8 +18,10 @@ int main(int argc, char **argv) {
     }
 
     const char *action = argv[1];
-    if (strcmp(action, "enable") != 0 && strcmp(action, "disable") != 0) {
-        fprintf(stderr, "_TERM_SHADER: action must be 'enable' or 'disable'.\n");
+    if (strcmp(action, "disable") != 0 &&
+        strcmp(action, "light") != 0 &&
+        strcmp(action, "shader") != 0) {
+        fprintf(stderr, "_TERM_SHADER: action must be 'disable', 'light', or 'shader'.\n");
         print_usage();
         return EXIT_FAILURE;
     }

--- a/commands/manual.md
+++ b/commands/manual.md
@@ -252,9 +252,12 @@ render only a single layer (1–16). Omitting `-layer` renders all layers.
 **Description:** Sets pixel scaling: `1` for original resolution, `2` for double.
 
 ### `_TERM_SHADER`
-**Usage:** `_TERM_SHADER <enable|disable>`
+**Usage:** `_TERM_SHADER <disable|light|shader>`
 
-**Description:** Enables or disables terminal shader passes.
+**Description:** Sets CRT post-processing mode in `apps/terminal`:
+- `disable`: no CRT post-processing.
+- `light`: lightweight CPU-based CRT simulation (curvature + scanlines), no shader stack required.
+- `shader`: full shader-stack CRT mode.
 
 ### `_TERM_SOUND_PLAY`
 **Usage:** `_TERM_SOUND_PLAY <channel> <audiofile> <volume>`

--- a/tasks/autoexec.task
+++ b/tasks/autoexec.task
@@ -359,7 +359,7 @@ IF ($MENU == "CONFIGURATION"):
   RUN _TEXT -x $MENU_X-3 -y 23 -text "Login Menu      = " + $LOGIN_MENU
   RUN _TEXT -x $MENU_X-3 -y 25 -text "Typing Sound    = " + $TYPING_SOUND
   RUN _TEXT -x $MENU_X-3 -y 27 -text "Retro Profile   = " + $RETROPROFILE
-  RUN _TEXT -x $MENU_X-3 -y 29 -text "Shader Passes   = " + $SHADER
+  RUN _TEXT -x $MENU_X-3 -y 29 -text "CRT Mode        = " + $SHADER
   RUN _TEXT -x $MENU_X-3 -y 31 -text "<-- MAIN MENU             "
   
   EVAL DRAW_CURSOR($CURSOR_X-3, $CURSOR_Y)
@@ -465,12 +465,15 @@ IF ($MENU == "CONFIGURATION"):
       END
     END
     IF ($CURSOR_Y == 29):
-      # Set shader passes
-      IF ($SHADER == "enable"):
-        RUN _CONFIG -write _TERM_SHADER disable
-      END
+      # Cycle CRT mode: disable -> light -> shader -> disable
       IF ($SHADER == "disable"):
-        RUN _CONFIG -write _TERM_SHADER enable
+        RUN _CONFIG -write _TERM_SHADER light
+      END
+      IF ($SHADER == "light"):
+        RUN _CONFIG -write _TERM_SHADER shader
+      END
+      IF ($SHADER == "shader"):
+        RUN _CONFIG -write _TERM_SHADER disable
       END
     END
     IF ($CURSOR_Y == 31):


### PR DESCRIPTION
### Motivation
- Provide a lightweight CPU-based CRT effect for `apps/terminal` so curvature and scanlines can be used without the full shader stack. 
- Make runtime CRT selection configurable from TASK scripts and OSC 777 so users can pick `disable`, `light`, or full `shader` modes.

### Description
- Change `_TERM_SHADER` command to accept `disable`, `light`, and `shader` modes and update its help output in `commands/_TERM_SHADER.c` and `commands/manual.md`.
- Add a `terminal_crt_mode` enum and state to `apps/terminal.c` and gate shader activity on `TERMINAL_CRT_MODE_SHADER` so shader passes only run in `shader` mode.
- Implement `terminal_apply_lightweight_crt()` in `apps/terminal.c`, a CPU-based CRT simulation that applies mild curvature warping and alternating-row scanline darkening directly on the framebuffer for `light` mode.
- Extend OSC 777 parsing in `apps/terminal.c` so `shader=<disable|light|shader>` sets the CRT mode at runtime (treating `shader=enable` as `shader` for compatibility) and update the terminal usage text.
- Update `tasks/autoexec.task` UI and logic to show and cycle `CRT Mode` through `disable -> light -> shader -> disable` when the configuration menu entry is activated.

### Testing
- Ran the repository-level build as required with `make clean all`, and the build completed successfully with no compiler warnings or errors; `./budo/build.sh` emitted a non-fatal message about missing SDL2 development files but the make targets were produced successfully.
- Verified that the modified `commands/_TERM_SHADER` binary is built and `apps/terminal` compiles with the new symbols and that the new manual text appears in `commands/manual.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04d0530f548327adf07b7bea87f1f8)