### PR TITLE
docs(help): add TASK commands list to TASK LANGUAGE section

### DIFF
--- a/documents/help.txt
+++ b/documents/help.txt
@@ -197,6 +197,52 @@
   floppycheck          : 'floppycheck ./file or ./folder/' estimates how many
                          standard floppy disks the given content will take.
 
+ /* TASK Commands from ./commands/ */
+
+  _BAR                 : Draw a titled progress bar (0-100%) at cursor or -x/-y.
+  _BEEP                : Play a tone with note and duration in milliseconds.
+  _CALC                : Evaluate a math expression and print the result.
+  _CLEAR               : Clear the terminal screen using ANSI escape sequences.
+  _CONFIG              : Read or write key-value settings in config.ini.
+  _CSVFILTER           : Filter semicolon-separated CSV rows with comparisons.
+  _CSVSTATS            : Compute count/sum/mean/min/max/variance/stddev from CSV.
+  _DICE                : Roll D&D dice notation like 2d20 and print total.
+  _DISPLAY             : Draw PNG/BMP image at text grid position -x/-y.
+  _EXE                 : Run app/utility and render output at -x/-y offset.
+  _FROMCSV             : Read one CSV cell by 1-based row and column index.
+  _GETHEIGHT           : Print terminal height in rows.
+  _GETROW              : Print current cursor row.
+  _GETWIDTH            : Print terminal width in columns.
+  _HELLO               : Print hello world test line.
+  _IMAGE               : Draw PNG/BMP image at text grid position -x/-y.
+  _KEYS                : Wait for key input and print mapped numeric key code.
+  _LIST                : List directory entries as TASK array literal.
+  _RECT                : Draw a filled or outlined rectangle using color index.
+  _RETROPROFILE        : List/show/apply/reset retro color profiles.
+  _TERM_CLEAN          : Clear pixel rectangle area from terminal render layer.
+  _TERM_CURSOR_BLINK   : Enable or disable blinking cursor in terminal.
+  _TERM_KEYBOARD       : Read buffered key events as TASK array literal.
+  _TERM_MARGIN         : Set terminal pixel render margin.
+  _TERM_MOUSE          : Read mouse X/Y and left/right button counters.
+  _TERM_MOUSE_SHOW     : Show or hide terminal mouse cursor.
+  _TERM_RENDER         : Trigger full render or render selected layer.
+  _TERM_RESOLUTION     : Set pixel resolution (LOW/HIGH or width/height).
+  _TERM_SCALE          : Set pixel scaling mode 1x or 2x.
+  _TERM_SHADER         : Enable or disable terminal shader.
+  _TERM_SOUND_PLAY     : Play audio file on selected channel (1-32) volume 0-100.
+  _TERM_SOUND_STOP     : Stop audio playback on selected channel (1-32).
+  _TERM_SPRITE         : Draw sprite from file/literal/base64 on chosen layer.
+  _TERM_SPRITE_LOAD    : Load sprite and output reusable TASK sprite literal.
+  _TERM_TEXT           : Draw UTF-8 text in pixel space with color and layer.
+  _TERM_TYPING_SOUND   : Enable or disable keyboard typing sound effects.
+  _TEST                : Print terminal diagnostic grid and size info.
+  _TEXT                : Print text at column/row with optional color.
+  _TIMER               : Start/stop/get/reset stopwatch in milliseconds.
+  _TOCSV               : Write value to CSV cell by 1-based row and column.
+  _TOFILE              : Show guidance for output logging via shell helper.
+  _VERSION             : Print current repository commit-count version.
+  _WAIT                : Sleep for given number of milliseconds.
+
  /* BUDOSTACK Example TASK Programs */
 
   audiodemo.task       : Collection of in-built sound capabilities


### PR DESCRIPTION
### Motivation

- Make TASK command discovery easier by surfacing short descriptions directly in the main help file. 
- Ensure the `TASK LANGUAGE` section documents the full set of commands implemented in `./commands/` so users can find command purpose without opening each source file.

### Description

- Updated `documents/help.txt` by inserting a `/* TASK Commands from ./commands/ */` block containing one-line descriptions for every command found in `./commands/`.
- Preserved the existing help formatting and alignment so the new block integrates with the surrounding sections.
- The change is limited to the help document and does not modify code or command implementations.

### Testing

- Ran `make clean all` from the repository root to validate the build artifacts. 
- Build completed successfully with no compiler warnings or errors; `./budo/build.sh` reported missing SDL2 development files (informational), but the overall `make` run finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061a3ba5f88327a69b0bca72bc891f)