### PR TITLE
Improve `utilities/list` output readability with dot-leaders

### DIFF
--- a/utilities/list.c
+++ b/utilities/list.c
@@ -13,6 +13,9 @@
 #include <sys/wait.h>
 
 #define NAME_DISPLAY_WIDTH 31
+#define PERMS_DISPLAY_WIDTH 11
+#define SIZE_DISPLAY_WIDTH 10
+#define GIT_DISPLAY_WIDTH 3
 
 // Global base path used in filter and comparator
 static const char *base_path;
@@ -132,6 +135,21 @@ static void format_display_name(const char *input, char *output, size_t width) {
     output[width] = '\0';
 }
 
+static void print_dot_field(const char *value, size_t width, int trailing_space) {
+    size_t len = strlen(value);
+    fputs(value, stdout);
+
+    if (len < width) {
+        for (size_t i = len; i < width; i++) {
+            putchar('.');
+        }
+    }
+
+    if (trailing_space) {
+        putchar(' ');
+    }
+}
+
 // Convert file mode to a permission string (similar to ls -l output)
 void mode_to_string(mode_t mode, char *str) {
     str[0] = S_ISDIR(mode) ? 'd' : (S_ISLNK(mode) ? 'l' : '-');
@@ -233,14 +251,17 @@ void print_file_info(const char *filepath, const char *display_name) {
     char truncated_name[NAME_DISPLAY_WIDTH + 1];
     format_display_name(formatted_name_buffer, truncated_name, NAME_DISPLAY_WIDTH);
 
-    printf(
-        "%-*s %-11s %-10ld %-3s %-20s\n",
-        NAME_DISPLAY_WIDTH,
-        truncated_name,
-        perms,
-        (long)st.st_size,
-        file_is_tracked(filepath) ? "x" : "",
-        timebuf);
+    char sizebuf[32];
+    char gitbuf[GIT_DISPLAY_WIDTH + 1];
+
+    snprintf(sizebuf, sizeof(sizebuf), "%ld", (long)st.st_size);
+    snprintf(gitbuf, sizeof(gitbuf), "%s", file_is_tracked(filepath) ? "x" : "");
+
+    print_dot_field(truncated_name, NAME_DISPLAY_WIDTH, 1);
+    print_dot_field(perms, PERMS_DISPLAY_WIDTH, 1);
+    print_dot_field(sizebuf, SIZE_DISPLAY_WIDTH, 1);
+    print_dot_field(gitbuf, GIT_DISPLAY_WIDTH, 1);
+    printf("%s\n", timebuf);
 }
 
 // List a single directory (non-recursive)
@@ -254,14 +275,11 @@ void list_directory(const char *dir_path) {
     }
 
     printf("\n");
-    printf(
-        "%-*s %-11s %-10s %-3s %-20s\n",
-        NAME_DISPLAY_WIDTH,
-        "Filename",
-        "Permissions",
-        "Size",
-        "Git",
-        "Last Modified");
+    print_dot_field("Filename", NAME_DISPLAY_WIDTH, 1);
+    print_dot_field("Permissions", PERMS_DISPLAY_WIDTH, 1);
+    print_dot_field("Size", SIZE_DISPLAY_WIDTH, 1);
+    print_dot_field("Git", GIT_DISPLAY_WIDTH, 1);
+    printf("%s\n", "Last Modified");
     print_separator();
 
     for (int i = 0; i < n; i++) {
@@ -391,14 +409,11 @@ void list_recursive_search(const char *pattern) {
         "Recursive search for %s matching pattern '%s':\n",
         list_folders_only ? "folders" : "files",
         pattern);
-    printf(
-        "%-*s %-11s %-10s %-3s %-20s\n",
-        NAME_DISPLAY_WIDTH,
-        "Filename",
-        "Permissions",
-        "Size",
-        "Git",
-        "Last Modified");
+    print_dot_field("Filename", NAME_DISPLAY_WIDTH, 1);
+    print_dot_field("Permissions", PERMS_DISPLAY_WIDTH, 1);
+    print_dot_field("Size", SIZE_DISPLAY_WIDTH, 1);
+    print_dot_field("Git", GIT_DISPLAY_WIDTH, 1);
+    printf("%s\n", "Last Modified");
     print_separator();
 
     for (size_t i = 0; i < matches_count; i++) {
@@ -492,14 +507,11 @@ int main(int argc, char *argv[]) {
 
     if (file_count > 0) {
         printf("Files:\n");
-        printf(
-            "%-*s %-11s %-10s %-3s %-20s\n",
-            NAME_DISPLAY_WIDTH,
-            "Filename",
-            "Permissions",
-            "Size",
-            "Git",
-            "Last Modified");
+        print_dot_field("Filename", NAME_DISPLAY_WIDTH, 1);
+        print_dot_field("Permissions", PERMS_DISPLAY_WIDTH, 1);
+        print_dot_field("Size", SIZE_DISPLAY_WIDTH, 1);
+        print_dot_field("Git", GIT_DISPLAY_WIDTH, 1);
+        printf("%s\n", "Last Modified");
         print_separator();
         for (int i = 0; i < file_count; i++) {
             print_file_info(file_paths[i], file_paths[i]);

--- a/utilities/list.c
+++ b/utilities/list.c
@@ -182,8 +182,8 @@ static void print_padded_field(const char *value, size_t width, int align_mode, 
     }
 }
 
-static void format_size_value(off_t size, char *buffer, size_t buffer_size) {
-    static const char *units[] = {"B", "kB", "MB", "GB", "TB"};
+static void format_size_parts(off_t size, char *number_buf, size_t number_buf_size, char *unit_buf, size_t unit_buf_size) {
+    static const char *units[] = {" B", "kB", "MB", "GB", "TB"};
     double value = (double)size;
     size_t unit_index = 0;
 
@@ -192,10 +192,35 @@ static void format_size_value(off_t size, char *buffer, size_t buffer_size) {
         unit_index++;
     }
 
+    snprintf(unit_buf, unit_buf_size, "%s", units[unit_index]);
     if (unit_index == 0) {
-        snprintf(buffer, buffer_size, "%ld %s", (long)size, units[unit_index]);
+        snprintf(number_buf, number_buf_size, "%ld", (long)size);
     } else {
-        snprintf(buffer, buffer_size, "%.1f %s", value, units[unit_index]);
+        snprintf(number_buf, number_buf_size, "%.1f", value);
+    }
+}
+
+static void print_size_field(off_t size, size_t width, int trailing_space) {
+    char number_buf[32];
+    char unit_buf[3];
+    size_t number_len;
+    size_t number_width;
+
+    format_size_parts(size, number_buf, sizeof(number_buf), unit_buf, sizeof(unit_buf));
+    number_len = strlen(number_buf);
+    number_width = width > 2 ? width - 2 : 0;
+
+    if (number_len < number_width) {
+        for (size_t i = number_len; i < number_width; i++) {
+            putchar('.');
+        }
+    }
+
+    fputs(number_buf, stdout);
+    fputs(unit_buf, stdout);
+
+    if (trailing_space) {
+        putchar(' ');
     }
 }
 
@@ -300,15 +325,13 @@ void print_file_info(const char *filepath, const char *display_name) {
     char truncated_name[NAME_DISPLAY_WIDTH + 1];
     format_display_name(formatted_name_buffer, truncated_name, NAME_DISPLAY_WIDTH);
 
-    char sizebuf[32];
     char gitbuf[GIT_DISPLAY_WIDTH + 1];
 
-    format_size_value(st.st_size, sizebuf, sizeof(sizebuf));
     snprintf(gitbuf, sizeof(gitbuf), "%s", file_is_tracked(filepath) ? "x" : "");
 
     print_dot_field(truncated_name, NAME_DISPLAY_WIDTH, 1);
     print_dot_field(perms, PERMS_DISPLAY_WIDTH, 1);
-    print_padded_field(sizebuf, SIZE_DISPLAY_WIDTH, 1, 1);
+    print_size_field(st.st_size, SIZE_DISPLAY_WIDTH, 1);
     print_padded_field(gitbuf, GIT_DISPLAY_WIDTH, 0, 1);
     printf("%s\n", timebuf);
 }

--- a/utilities/list.c
+++ b/utilities/list.c
@@ -225,6 +225,16 @@ static void print_size_field(off_t size, size_t width, int trailing_space) {
     }
 }
 
+static void print_size_placeholder(size_t width, int trailing_space) {
+    for (size_t i = 0; i < width; i++) {
+        putchar('.');
+    }
+
+    if (trailing_space) {
+        putchar(' ');
+    }
+}
+
 // Convert file mode to a permission string (similar to ls -l output)
 void mode_to_string(mode_t mode, char *str) {
     str[0] = S_ISDIR(mode) ? 'd' : (S_ISLNK(mode) ? 'l' : '-');
@@ -333,7 +343,7 @@ void print_file_info(const char *filepath, const char *display_name) {
     print_dot_field(truncated_name, NAME_DISPLAY_WIDTH, 1);
     print_dot_field(perms, PERMS_DISPLAY_WIDTH, 0);
     if (S_ISDIR(st.st_mode)) {
-        print_padded_field("", SIZE_DISPLAY_WIDTH, 1, 1);
+        print_size_placeholder(SIZE_DISPLAY_WIDTH, 1);
     } else {
         print_size_field(st.st_size, SIZE_DISPLAY_WIDTH, 1);
     }

--- a/utilities/list.c
+++ b/utilities/list.c
@@ -14,7 +14,7 @@
 
 #define NAME_DISPLAY_WIDTH 31
 #define PERMS_DISPLAY_WIDTH 11
-#define SIZE_DISPLAY_WIDTH 10
+#define SIZE_DISPLAY_WIDTH 12
 #define GIT_DISPLAY_WIDTH 3
 
 // Global base path used in filter and comparator
@@ -140,13 +140,32 @@ static void print_dot_field(const char *value, size_t width, int trailing_space)
     fputs(value, stdout);
 
     if (len < width) {
-        for (size_t i = len; i < width; i++) {
+        putchar(' ');
+        for (size_t i = len + 1; i < width; i++) {
             putchar('.');
         }
     }
 
     if (trailing_space) {
         putchar(' ');
+    }
+}
+
+
+static void format_size_value(off_t size, char *buffer, size_t buffer_size) {
+    static const char *units[] = {"B", "kB", "MB", "GB", "TB"};
+    double value = (double)size;
+    size_t unit_index = 0;
+
+    while (value >= 1024.0 && unit_index < (sizeof(units) / sizeof(units[0])) - 1) {
+        value /= 1024.0;
+        unit_index++;
+    }
+
+    if (unit_index == 0) {
+        snprintf(buffer, buffer_size, "%ld %s", (long)size, units[unit_index]);
+    } else {
+        snprintf(buffer, buffer_size, "%.1f %s", value, units[unit_index]);
     }
 }
 
@@ -254,7 +273,7 @@ void print_file_info(const char *filepath, const char *display_name) {
     char sizebuf[32];
     char gitbuf[GIT_DISPLAY_WIDTH + 1];
 
-    snprintf(sizebuf, sizeof(sizebuf), "%ld", (long)st.st_size);
+    format_size_value(st.st_size, sizebuf, sizeof(sizebuf));
     snprintf(gitbuf, sizeof(gitbuf), "%s", file_is_tracked(filepath) ? "x" : "");
 
     print_dot_field(truncated_name, NAME_DISPLAY_WIDTH, 1);

--- a/utilities/list.c
+++ b/utilities/list.c
@@ -183,7 +183,7 @@ static void print_padded_field(const char *value, size_t width, int align_mode, 
 }
 
 static void format_size_parts(off_t size, char *number_buf, size_t number_buf_size, char *unit_buf, size_t unit_buf_size) {
-    static const char *units[] = {" B", "kB", "MB", "GB", "TB"};
+    static const char *units[] = {"B", "kB", "MB", "GB", "TB"};
     double value = (double)size;
     size_t unit_index = 0;
 
@@ -208,7 +208,7 @@ static void print_size_field(off_t size, size_t width, int trailing_space) {
 
     format_size_parts(size, number_buf, sizeof(number_buf), unit_buf, sizeof(unit_buf));
     number_len = strlen(number_buf);
-    number_width = width > 2 ? width - 2 : 0;
+    number_width = width > 3 ? width - 3 : 0;
 
     if (number_len < number_width) {
         for (size_t i = number_len; i < number_width; i++) {
@@ -217,6 +217,7 @@ static void print_size_field(off_t size, size_t width, int trailing_space) {
     }
 
     fputs(number_buf, stdout);
+    putchar(' ');
     fputs(unit_buf, stdout);
 
     if (trailing_space) {
@@ -330,8 +331,12 @@ void print_file_info(const char *filepath, const char *display_name) {
     snprintf(gitbuf, sizeof(gitbuf), "%s", file_is_tracked(filepath) ? "x" : "");
 
     print_dot_field(truncated_name, NAME_DISPLAY_WIDTH, 1);
-    print_dot_field(perms, PERMS_DISPLAY_WIDTH, 1);
-    print_size_field(st.st_size, SIZE_DISPLAY_WIDTH, 1);
+    print_dot_field(perms, PERMS_DISPLAY_WIDTH, 0);
+    if (S_ISDIR(st.st_mode)) {
+        print_padded_field("", SIZE_DISPLAY_WIDTH, 1, 1);
+    } else {
+        print_size_field(st.st_size, SIZE_DISPLAY_WIDTH, 1);
+    }
     print_padded_field(gitbuf, GIT_DISPLAY_WIDTH, 0, 1);
     printf("%s\n", timebuf);
 }

--- a/utilities/list.c
+++ b/utilities/list.c
@@ -152,6 +152,36 @@ static void print_dot_field(const char *value, size_t width, int trailing_space)
 }
 
 
+static void print_padded_field(const char *value, size_t width, int align_mode, int trailing_space) {
+    size_t len = strlen(value);
+    size_t left_pad = 0;
+    size_t right_pad = 0;
+
+    if (len < width) {
+        size_t pad_total = width - len;
+        if (align_mode > 0) {
+            left_pad = pad_total;
+        } else if (align_mode < 0) {
+            right_pad = pad_total;
+        } else {
+            left_pad = pad_total / 2;
+            right_pad = pad_total - left_pad;
+        }
+    }
+
+    for (size_t i = 0; i < left_pad; i++) {
+        putchar(' ');
+    }
+    fputs(value, stdout);
+    for (size_t i = 0; i < right_pad; i++) {
+        putchar(' ');
+    }
+
+    if (trailing_space) {
+        putchar(' ');
+    }
+}
+
 static void format_size_value(off_t size, char *buffer, size_t buffer_size) {
     static const char *units[] = {"B", "kB", "MB", "GB", "TB"};
     double value = (double)size;
@@ -278,8 +308,8 @@ void print_file_info(const char *filepath, const char *display_name) {
 
     print_dot_field(truncated_name, NAME_DISPLAY_WIDTH, 1);
     print_dot_field(perms, PERMS_DISPLAY_WIDTH, 1);
-    print_dot_field(sizebuf, SIZE_DISPLAY_WIDTH, 1);
-    print_dot_field(gitbuf, GIT_DISPLAY_WIDTH, 1);
+    print_padded_field(sizebuf, SIZE_DISPLAY_WIDTH, 1, 1);
+    print_padded_field(gitbuf, GIT_DISPLAY_WIDTH, 0, 1);
     printf("%s\n", timebuf);
 }
 
@@ -294,10 +324,10 @@ void list_directory(const char *dir_path) {
     }
 
     printf("\n");
-    print_dot_field("Filename", NAME_DISPLAY_WIDTH, 1);
-    print_dot_field("Permissions", PERMS_DISPLAY_WIDTH, 1);
-    print_dot_field("Size", SIZE_DISPLAY_WIDTH, 1);
-    print_dot_field("Git", GIT_DISPLAY_WIDTH, 1);
+    print_padded_field("Filename", NAME_DISPLAY_WIDTH, -1, 1);
+    print_padded_field("Permissions", PERMS_DISPLAY_WIDTH, -1, 1);
+    print_padded_field("Size", SIZE_DISPLAY_WIDTH, 0, 1);
+    print_padded_field("Git", GIT_DISPLAY_WIDTH, 0, 1);
     printf("%s\n", "Last Modified");
     print_separator();
 
@@ -428,10 +458,10 @@ void list_recursive_search(const char *pattern) {
         "Recursive search for %s matching pattern '%s':\n",
         list_folders_only ? "folders" : "files",
         pattern);
-    print_dot_field("Filename", NAME_DISPLAY_WIDTH, 1);
-    print_dot_field("Permissions", PERMS_DISPLAY_WIDTH, 1);
-    print_dot_field("Size", SIZE_DISPLAY_WIDTH, 1);
-    print_dot_field("Git", GIT_DISPLAY_WIDTH, 1);
+    print_padded_field("Filename", NAME_DISPLAY_WIDTH, -1, 1);
+    print_padded_field("Permissions", PERMS_DISPLAY_WIDTH, -1, 1);
+    print_padded_field("Size", SIZE_DISPLAY_WIDTH, 0, 1);
+    print_padded_field("Git", GIT_DISPLAY_WIDTH, 0, 1);
     printf("%s\n", "Last Modified");
     print_separator();
 
@@ -526,10 +556,10 @@ int main(int argc, char *argv[]) {
 
     if (file_count > 0) {
         printf("Files:\n");
-        print_dot_field("Filename", NAME_DISPLAY_WIDTH, 1);
-        print_dot_field("Permissions", PERMS_DISPLAY_WIDTH, 1);
-        print_dot_field("Size", SIZE_DISPLAY_WIDTH, 1);
-        print_dot_field("Git", GIT_DISPLAY_WIDTH, 1);
+        print_padded_field("Filename", NAME_DISPLAY_WIDTH, -1, 1);
+        print_padded_field("Permissions", PERMS_DISPLAY_WIDTH, -1, 1);
+        print_padded_field("Size", SIZE_DISPLAY_WIDTH, 0, 1);
+        print_padded_field("Git", GIT_DISPLAY_WIDTH, 0, 1);
         printf("%s\n", "Last Modified");
         print_separator();
         for (int i = 0; i < file_count; i++) {


### PR DESCRIPTION
### Motivation
- Make the `list` utility output easier to scan by visually connecting columns with dot leaders so each row ties filename to its metadata.
- Keep formatting consistent and maintainable by introducing explicit column width constants and a small helper function.

### Description
- Added column width constants: `PERMS_DISPLAY_WIDTH`, `SIZE_DISPLAY_WIDTH`, and `GIT_DISPLAY_WIDTH`, and reused existing `NAME_DISPLAY_WIDTH` in `utilities/list.c`.
- Introduced `print_dot_field()` which prints a value and fills the remaining column width with `.` characters and an optional trailing space.
- Replaced previous space-padded `printf` table headers and data rows with calls to `print_dot_field()` for directory listings, recursive search results, and explicit file lists so rows render like `name....permissions...size...git...last-modified`.
- Kept existing behavior for truncation and git detection; only changed presentation logic in `utilities/list.c`.

### Testing
- Ran `make clean all` from the repository root which completed successfully and produced the updated `utilities/list` binary with compilation under `-Werror` passing.
- The build run emits the known `./budo/build.sh` SDL2 development files warning in this environment but it does not affect the compilation of `utilities/list` and overall build success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10982f736c83279d93c03598f13b3d)