### PR TITLE
Remove leading dash before directory names in utilities/list.c

### DIFF
--- a/utilities/list.c
+++ b/utilities/list.c
@@ -300,7 +300,7 @@ void print_file_info(const char *filepath, const char *display_name) {
 
     char formatted_name_buffer[1024];
     if (S_ISDIR(st.st_mode) && strcmp(display_name, ".") != 0 && strcmp(display_name, "..") != 0) {
-        snprintf(formatted_name_buffer, sizeof(formatted_name_buffer), "-%s/", display_name);
+        snprintf(formatted_name_buffer, sizeof(formatted_name_buffer), "%s/", display_name);
     } else {
         snprintf(formatted_name_buffer, sizeof(formatted_name_buffer), "%s", display_name);
     }


### PR DESCRIPTION
### Motivation
- The list utility printed an unnecessary leading `-` for directories (e.g. `-name/`) which produced a stray dash between the table header and the first row, so the display should show `name/` instead.

### Description
- Update `utilities/list.c` to stop prefixing directory display names with `-` by changing the formatted output from `"-%s/"` to `"%s/"` when constructing `formatted_name_buffer` for directories.

### Testing
- Ran `make clean all` from the repository root and the build completed successfully with no compiler warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12a3a9933083279ae6841f2c5fd920)