### PR TITLE
Fix blank Git column row formatting in utilities list output

### DIFF
--- a/utilities/list.c
+++ b/utilities/list.c
@@ -211,20 +211,6 @@ static void format_dotted_field(const char *input, char *output, size_t width) {
     memcpy(output + dots, input, input_len + 1);
 }
 
-static void format_center_dotted_field(const char *input, char *output, size_t width) {
-    size_t input_len = strlen(input);
-    if (input_len >= width) {
-        memcpy(output, input, width);
-        output[width] = '\0';
-        return;
-    }
-
-    memset(output, '.', width);
-    size_t offset = (width - input_len) / 2;
-    memcpy(output + offset, input, input_len);
-    output[width] = '\0';
-}
-
 static void format_center_space_field(const char *input, char *output, size_t width) {
     size_t input_len = strlen(input);
     if (input_len >= width) {
@@ -323,7 +309,7 @@ void print_file_info(const char *filepath, const char *display_name) {
         memset(size_unit, '.', SIZE_UNIT_WIDTH);
         size_unit[SIZE_UNIT_WIDTH] = '\0';
     }
-    format_center_dotted_field(file_is_tracked(filepath) ? "X" : "", git_value, 3);
+    format_center_space_field(file_is_tracked(filepath) ? "X" : "", git_value, 3);
 
     printf(
         "%-*s %-11s %s %s %s %-20s\n",


### PR DESCRIPTION
### Motivation

- Ensure rows that have no Git tracking display an empty Git cell (truly blank) instead of dotted/dashed characters to improve alignment and readability of the table. 
- Remove dead code that triggered `-Werror` warnings to keep the repository build-clean under strict compiler flags.

### Description

- Replace use of `format_center_dotted_field` with `format_center_space_field` when populating the Git column so empty values render as spaces rather than dots/dashes (`utilities/list.c`).
- Remove the now-unused helper `format_center_dotted_field` from `utilities/list.c` to eliminate an unused-function warning.

### Testing

- Ran `make clean all` from the repository root and confirmed a full rebuild completed successfully with no compiler warnings or errors. 
- Verified the `utilities/list` binary was built and linked without issues after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12adf6a460832785ca5f54059f4382)