### PR TITLE
apps/paint: add selection toggle with cut/copy/paste tool

### DIFF
--- a/apps/paint.c
+++ b/apps/paint.c
@@ -1204,9 +1204,17 @@ static void draw_selection_border_cell(uint8_t idx, int x, int y) {
             return;
         }
     }
-    const char *seq = brighten ? "\x1b[97m" : "\x1b[30m";
-    write(STDOUT_FILENO, seq, 5);
-    write(STDOUT_FILENO, "#", 1);
+    Color empty_border_color = {
+        brighten ? 235 : 35,
+        brighten ? 235 : 35,
+        brighten ? 235 : 35,
+        'A',
+        "SelectionBorderEmpty",
+        0
+    };
+    set_bg_color_ansi(&empty_border_color);
+    write(STDOUT_FILENO, "\x1b[39m", 5);
+    write(STDOUT_FILENO, " ", 1);
     reset_ansi_colors();
 #else
     (void)idx;

--- a/apps/paint.c
+++ b/apps/paint.c
@@ -156,7 +156,7 @@ static void prompt(const char *msg, char *out, size_t cap);
 static int refresh_cursor_cell_partial(void);
 static int update_cursor_partial(int old_x, int old_y);
 static int selection_is_active(void);
-static int point_in_selection(int x, int y);
+static int point_on_selection_border(int x, int y);
 static int copy_selection_to_clipboard(int cut);
 static int paste_clipboard_at_cursor(void);
 
@@ -1176,13 +1176,46 @@ static int selection_is_active(void) {
     return select_tool_active && selection_has_anchor;
 }
 
-static int point_in_selection(int x, int y) {
+static int point_on_selection_border(int x, int y) {
     if (!selection_is_active()) return 0;
     int x0 = selection_start_x < cursor_x ? selection_start_x : cursor_x;
     int y0 = selection_start_y < cursor_y ? selection_start_y : cursor_y;
     int x1 = selection_start_x > cursor_x ? selection_start_x : cursor_x;
     int y1 = selection_start_y > cursor_y ? selection_start_y : cursor_y;
-    return x >= x0 && x <= x1 && y >= y0 && y <= y1;
+    if (x < x0 || x > x1 || y < y0 || y > y1) return 0;
+    return x == x0 || x == x1 || y == y0 || y == y1;
+}
+
+static void draw_selection_border_cell(uint8_t idx, int x, int y) {
+#if USE_ANSI_COLOR
+    int brighten = ((x + y) & 1) == 0;
+    if (idx != EMPTY && idx < TOTAL_COLORS) {
+        const Color *base = color_from_index(idx);
+        if (base) {
+            Color adjusted = *base;
+            float factor = brighten ? 1.25f : 0.75f;
+            adjusted.r = apply_brightness(base->r, factor);
+            adjusted.g = apply_brightness(base->g, factor);
+            adjusted.b = apply_brightness(base->b, factor);
+            set_bg_color_ansi(&adjusted);
+            write(STDOUT_FILENO, "\x1b[39m", 5);
+            write(STDOUT_FILENO, " ", 1);
+            reset_ansi_colors();
+            return;
+        }
+    }
+    const char *seq = brighten ? "\x1b[97m" : "\x1b[30m";
+    write(STDOUT_FILENO, seq, 5);
+    write(STDOUT_FILENO, "#", 1);
+    reset_ansi_colors();
+#else
+    (void)idx;
+    (void)x;
+    (void)y;
+    write(STDOUT_FILENO, "\x1b[7m", 4);
+    write(STDOUT_FILENO, "#", 1);
+    write(STDOUT_FILENO, "\x1b[0m", 4);
+#endif
 }
 
 typedef struct {
@@ -1315,8 +1348,14 @@ static void render(void){
 
             uint8_t idx = pixels[y * img_w + x];
             int cursor_here = (x == cursor_x && y == cursor_y);
-            int selection_here = point_in_selection(x, y);
-            draw_cell(idx, cursor_here || selection_here);
+            int selection_border = point_on_selection_border(x, y);
+            if (cursor_here) {
+                draw_cell(idx, 1);
+            } else if (selection_border) {
+                draw_selection_border_cell(idx, x, y);
+            } else {
+                draw_cell(idx, 0);
+            }
         }
     }
 

--- a/apps/paint.c
+++ b/apps/paint.c
@@ -793,7 +793,7 @@ static int handle_key_event(int key, int *running) {
                 int old_x = cursor_x;
                 int old_y = cursor_y;
                 cursor_y--;
-                if (!update_cursor_partial(old_x, old_y)) {
+                if (selection_is_active() || !update_cursor_partial(old_x, old_y)) {
                     need_render = 1;
                 }
             }
@@ -803,7 +803,7 @@ static int handle_key_event(int key, int *running) {
                 int old_x = cursor_x;
                 int old_y = cursor_y;
                 cursor_y++;
-                if (!update_cursor_partial(old_x, old_y)) {
+                if (selection_is_active() || !update_cursor_partial(old_x, old_y)) {
                     need_render = 1;
                 }
             }
@@ -813,7 +813,7 @@ static int handle_key_event(int key, int *running) {
                 int old_x = cursor_x;
                 int old_y = cursor_y;
                 cursor_x--;
-                if (!update_cursor_partial(old_x, old_y)) {
+                if (selection_is_active() || !update_cursor_partial(old_x, old_y)) {
                     need_render = 1;
                 }
             }
@@ -823,7 +823,7 @@ static int handle_key_event(int key, int *running) {
                 int old_x = cursor_x;
                 int old_y = cursor_y;
                 cursor_x++;
-                if (!update_cursor_partial(old_x, old_y)) {
+                if (selection_is_active() || !update_cursor_partial(old_x, old_y)) {
                     need_render = 1;
                 }
             }

--- a/apps/paint.c
+++ b/apps/paint.c
@@ -124,6 +124,13 @@ static int view_x = 0, view_y = 0;
 static int dirty = 0; // unsaved changes
 static int fill_color_pending = 0;
 static char current_file_path[512];
+static int select_tool_active = 0;
+static int selection_has_anchor = 0;
+static int selection_start_x = 0;
+static int selection_start_y = 0;
+static int clipboard_w = 0;
+static int clipboard_h = 0;
+static uint8_t clipboard_pixels[MAX_W * MAX_H];
 
 static void set_current_file_path(const char *path) {
     if (!path || !*path) {
@@ -148,6 +155,10 @@ static int redo_action(void);
 static void prompt(const char *msg, char *out, size_t cap);
 static int refresh_cursor_cell_partial(void);
 static int update_cursor_partial(int old_x, int old_y);
+static int selection_is_active(void);
+static int point_in_selection(int x, int y);
+static int copy_selection_to_clipboard(int cut);
+static int paste_clipboard_at_cursor(void);
 
 /* Palette: 26 entries mapped to letters A..Z (RGB 0..255) */
 typedef struct { uint8_t r,g,b; char letter; const char *name; int term256; } Color;
@@ -878,6 +889,32 @@ static int handle_key_event(int key, int *running) {
                 need_render = 1;
             }
             break;
+        case 20: /* Ctrl+T */
+            select_tool_active = !select_tool_active;
+            if (select_tool_active) {
+                selection_has_anchor = 1;
+                selection_start_x = cursor_x;
+                selection_start_y = cursor_y;
+            } else {
+                selection_has_anchor = 0;
+            }
+            need_render = 1;
+            break;
+        case 3:  /* Ctrl+C */
+            if (copy_selection_to_clipboard(0)) {
+                need_render = 1;
+            }
+            break;
+        case 24: /* Ctrl+X */
+            if (copy_selection_to_clipboard(1)) {
+                need_render = 1;
+            }
+            break;
+        case 22: /* Ctrl+V */
+            if (paste_clipboard_at_cursor()) {
+                need_render = 1;
+            }
+            break;
         case 17: /* Ctrl+Q */
             if (dirty) {
                 char ans[8];
@@ -934,10 +971,11 @@ static int build_status_lines(int cols, char lines[][256], int max_lines) {
     }
     char line1[256];
     const char *fill_msg = fill_color_pending ? "  Fill:Pick color" : "";
+    const char *select_msg = select_tool_active ? "  Select:ON" : "";
     snprintf(line1, sizeof(line1),
-        " %dx%d  Cursor:%d,%d  View:%d,%d  Palette:^1-^5:%d  %s%s",
+        " %dx%d  Cursor:%d,%d  View:%d,%d  Palette:^1-^5:%d  %s%s%s",
         img_w, img_h, cursor_x, cursor_y, view_x, view_y,
-        current_palette_variant + 1, dirty ? "Dirty" : "Saved", fill_msg);
+        current_palette_variant + 1, dirty ? "Dirty" : "Saved", fill_msg, select_msg);
     line1[sizeof(line1) - 1] = '\0';
     strncpy(lines[0], line1, sizeof(lines[0]) - 1);
     lines[0][sizeof(lines[0]) - 1] = '\0';
@@ -951,6 +989,10 @@ static int build_status_lines(int cols, char lines[][256], int max_lines) {
         "Brightness:^1-^5",
         "Erase:Backspace/Delete",
         "Resize:^R",
+        "Select:^T",
+        "Copy:^C",
+        "Cut:^X",
+        "Paste:^V",
         "Undo:^Z",
         "Redo:^Y",
         "Save:^S",
@@ -1130,6 +1172,19 @@ static void draw_cell(uint8_t idx, int highlight){
     reset_ansi_colors();
 }
 
+static int selection_is_active(void) {
+    return select_tool_active && selection_has_anchor;
+}
+
+static int point_in_selection(int x, int y) {
+    if (!selection_is_active()) return 0;
+    int x0 = selection_start_x < cursor_x ? selection_start_x : cursor_x;
+    int y0 = selection_start_y < cursor_y ? selection_start_y : cursor_y;
+    int x1 = selection_start_x > cursor_x ? selection_start_x : cursor_x;
+    int y1 = selection_start_y > cursor_y ? selection_start_y : cursor_y;
+    return x >= x0 && x <= x1 && y >= y0 && y <= y1;
+}
+
 typedef struct {
     int rows;
     int cols;
@@ -1259,7 +1314,9 @@ static void render(void){
             }
 
             uint8_t idx = pixels[y * img_w + x];
-            draw_cell(idx, x == cursor_x && y == cursor_y);
+            int cursor_here = (x == cursor_x && y == cursor_y);
+            int selection_here = point_in_selection(x, y);
+            draw_cell(idx, cursor_here || selection_here);
         }
     }
 
@@ -1401,6 +1458,74 @@ static int paint_at_cursor(uint8_t color_idx){
     *p = color_idx;
     dirty = 1;
     return 1;
+}
+
+static int copy_selection_to_clipboard(int cut) {
+    if (!selection_is_active()) return 0;
+    int x0 = selection_start_x < cursor_x ? selection_start_x : cursor_x;
+    int y0 = selection_start_y < cursor_y ? selection_start_y : cursor_y;
+    int x1 = selection_start_x > cursor_x ? selection_start_x : cursor_x;
+    int y1 = selection_start_y > cursor_y ? selection_start_y : cursor_y;
+    int w = x1 - x0 + 1;
+    int h = y1 - y0 + 1;
+    if (w <= 0 || h <= 0 || w > MAX_W || h > MAX_H) return 0;
+
+    clipboard_w = w;
+    clipboard_h = h;
+    for (int y = 0; y < h; y++) {
+        for (int x = 0; x < w; x++) {
+            clipboard_pixels[y * w + x] = pixels[(y0 + y) * img_w + (x0 + x)];
+        }
+    }
+
+    if (cut) {
+        size_t changed_count = 0;
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                int px = x0 + x;
+                int py = y0 + y;
+                uint8_t *p = &pixels[py * img_w + px];
+                if (*p != EMPTY) {
+                    push_change((uint16_t)px, (uint16_t)py, *p, EMPTY);
+                    *p = EMPTY;
+                    changed_count++;
+                }
+            }
+        }
+        if (changed_count > 0) {
+            push_change_marker(changed_count);
+            dirty = 1;
+        }
+    }
+
+    select_tool_active = 0;
+    selection_has_anchor = 0;
+    return 1;
+}
+
+static int paste_clipboard_at_cursor(void) {
+    if (clipboard_w <= 0 || clipboard_h <= 0) return 0;
+    size_t changed_count = 0;
+    for (int y = 0; y < clipboard_h; y++) {
+        int py = cursor_y + y;
+        if (py < 0 || py >= img_h) continue;
+        for (int x = 0; x < clipboard_w; x++) {
+            int px = cursor_x + x;
+            if (px < 0 || px >= img_w) continue;
+            uint8_t src = clipboard_pixels[y * clipboard_w + x];
+            uint8_t *dst = &pixels[py * img_w + px];
+            if (*dst == src) continue;
+            push_change((uint16_t)px, (uint16_t)py, *dst, src);
+            *dst = src;
+            changed_count++;
+        }
+    }
+    if (changed_count > 0) {
+        push_change_marker(changed_count);
+        dirty = 1;
+        return 1;
+    }
+    return 0;
 }
 
 static void flood_fill_at_cursor(uint8_t color_idx){

--- a/apps/paint.c
+++ b/apps/paint.c
@@ -1186,17 +1186,42 @@ static int point_on_selection_border(int x, int y) {
     return x == x0 || x == x1 || y == y0 || y == y1;
 }
 
+static int color_luma(const Color *c) {
+    if (!c) return 0;
+    return ((int)c->r * 299 + (int)c->g * 587 + (int)c->b * 114) / 1000;
+}
+
+static Color border_variant_from_base(const Color *base, int brighten) {
+    Color out = *base;
+    if (brighten) {
+        out.r = apply_brightness(base->r, 1.5f);
+        out.g = apply_brightness(base->g, 1.5f);
+        out.b = apply_brightness(base->b, 1.5f);
+        if (color_luma(&out) < 96) {
+            out.r = clamp_u8((int)out.r + 96);
+            out.g = clamp_u8((int)out.g + 96);
+            out.b = clamp_u8((int)out.b + 96);
+        }
+    } else {
+        out.r = apply_brightness(base->r, 0.5f);
+        out.g = apply_brightness(base->g, 0.5f);
+        out.b = apply_brightness(base->b, 0.5f);
+        if (color_luma(&out) > 160) {
+            out.r = clamp_u8((int)out.r - 96);
+            out.g = clamp_u8((int)out.g - 96);
+            out.b = clamp_u8((int)out.b - 96);
+        }
+    }
+    return out;
+}
+
 static void draw_selection_border_cell(uint8_t idx, int x, int y) {
 #if USE_ANSI_COLOR
     int brighten = ((x + y) & 1) == 0;
     if (idx != EMPTY && idx < TOTAL_COLORS) {
         const Color *base = color_from_index(idx);
         if (base) {
-            Color adjusted = *base;
-            float factor = brighten ? 1.25f : 0.75f;
-            adjusted.r = apply_brightness(base->r, factor);
-            adjusted.g = apply_brightness(base->g, factor);
-            adjusted.b = apply_brightness(base->b, factor);
+            Color adjusted = border_variant_from_base(base, brighten);
             set_bg_color_ansi(&adjusted);
             write(STDOUT_FILENO, "\x1b[39m", 5);
             write(STDOUT_FILENO, " ", 1);


### PR DESCRIPTION
### Motivation
- Provide a simple rectangular selection tool so users can select, copy, cut and paste pixel regions within the terminal paint app.
- Allow selection to be toggled and visually indicated while the tool is active so users can reposition the rectangle before copying/cutting.
- Make clipboard operations integrate with existing undo/redo so edits remain reversible.

### Description
- Added selection state and clipboard storage in `apps/paint.c` with new globals `select_tool_active`, `selection_start_*`, `clipboard_*`, and `clipboard_pixels` and helper functions `selection_is_active`, `point_in_selection`, `copy_selection_to_clipboard`, and `paste_clipboard_at_cursor`.
- Added keyboard bindings: `Ctrl+T` toggles selection mode and anchors the rectangle, `Ctrl+C` copies, `Ctrl+X` cuts (copy + clear source), and `Ctrl+V` pastes with the cursor as the top-left destination.
- Render and UI updated to highlight the rectangular selection while active and to add selection state and new shortcuts to the status/help lines (`Select:^T`, `Copy:^C`, `Cut:^X`, `Paste:^V`).
- Cut/copy/paste operations push change markers into the undo stack and clip paste operations to image bounds so they participate in `undo_action`/`redo_action` and avoid out-of-range writes.

### Testing
- Built the full project from the repo root using `make clean all` and the build completed successfully with no warnings/errors for `apps/paint.c` under the project compiler flags.
- Confirmed `apps/paint` object linked successfully during the build and the modified binary target compiled cleanly.
- The build shows an unrelated environment warning from `./budo/build.sh` about missing SDL2 development files, but this does not affect the terminal paint app build success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ae8d53b883278edba7b71cc0b458)