### PR TITLE
Update palette brightness factors in paint app

### DIFF
--- a/apps/paint.c
+++ b/apps/paint.c
@@ -245,7 +245,7 @@ static uint8_t apply_brightness(uint8_t value, float factor) {
 static void init_palettes(void) {
     static int initialized = 0;
     if (initialized) return;
-    const float factors[PALETTE_VARIANTS] = {0.15f, 0.3f, 0.45f, 0.8f, 1.25};
+    const float factors[PALETTE_VARIANTS] = {0.03f, 0.12f, 0.4135f, 0.8f, 0.797f};
     for (int variant = 0; variant < PALETTE_VARIANTS; variant++) {
         for (int i = 0; i < PALETTE_COLORS; i++) {
             Color c = base_palette[i];

--- a/apps/paint.c
+++ b/apps/paint.c
@@ -245,7 +245,7 @@ static uint8_t apply_brightness(uint8_t value, float factor) {
 static void init_palettes(void) {
     static int initialized = 0;
     if (initialized) return;
-    const float factors[PALETTE_VARIANTS] = {0.03f, 0.12f, 0.4135f, 0.8f, 0.797f};
+    const float factors[PALETTE_VARIANTS] = {0.03f, 0.12f, 0.4135f, 0.8f, 1.25f};
     for (int variant = 0; variant < PALETTE_VARIANTS; variant++) {
         for (int i = 0; i < PALETTE_COLORS; i++) {
             Color c = base_palette[i];


### PR DESCRIPTION
### Motivation
- Adjust the per-variant brightness scaling factors used to derive runtime palettes so the color ramps and contrast behave differently across palette variants.

### Description
- Replace the `factors` array in `init_palettes()` with new float values so `apply_brightness()` generates updated palette variants, leaving the gamma correction and ANSI conversion logic unchanged.

### Testing
- Built the project (`make`) to validate compilation and no automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12c179f570832788c0bb88d22be1c5)