### PR TITLE
apps/paint: add temporary +/- palette brightness controls

### DIFF
--- a/apps/paint.c
+++ b/apps/paint.c
@@ -6,7 +6,7 @@
  *  - Arrow-keys move cursor, auto-scrolling viewport
  *  - A–Z paints with 26-color palette; Backspace/Delete erases
  *  - Ctrl+F then color floods a region using 4-direction adjacency
- *  - Ctrl+1..Ctrl+5 cycle palette brightness (3 = default)
+ *  - 1..5 select palette; +/- temporarily adjusts selected palette brightness
  *  - Max resolution 320x200
  *  - Works in a terminal using raw mode (termios) + ANSI escapes
  *
@@ -193,6 +193,8 @@ static const Color base_palette[PALETTE_COLORS] = {
 
 static Color palettes[PALETTE_VARIANTS][PALETTE_COLORS];
 static int current_palette_variant = 2; /* 0-based; palette 3 is default */
+static const float palette_base_factors[PALETTE_VARIANTS] = {0.03f, 0.12f, 0.4135f, 1.0f, 5.0f};
+static float palette_brightness_offsets[PALETTE_VARIANTS] = {0};
 
 static uint8_t clamp_u8(int v) {
     if (v < 0) return 0;
@@ -242,20 +244,30 @@ static uint8_t apply_brightness(uint8_t value, float factor) {
     return clamp_u8(out);
 }
 
+static float clamp_brightness_factor(float factor) {
+    if (factor < 0.01f) return 0.01f;
+    if (factor > 8.0f) return 8.0f;
+    return factor;
+}
+
+static void rebuild_palette_variant(int variant) {
+    if (variant < 0 || variant >= PALETTE_VARIANTS) return;
+    float factor = clamp_brightness_factor(palette_base_factors[variant] + palette_brightness_offsets[variant]);
+    for (int i = 0; i < PALETTE_COLORS; i++) {
+        Color c = base_palette[i];
+        c.r = apply_brightness(base_palette[i].r, factor);
+        c.g = apply_brightness(base_palette[i].g, factor);
+        c.b = apply_brightness(base_palette[i].b, factor);
+        c.term256 = rgb_to_ansi256(c.r, c.g, c.b);
+        palettes[variant][i] = c;
+    }
+}
+
 static void init_palettes(void) {
     static int initialized = 0;
     if (initialized) return;
-    const float factors[PALETTE_VARIANTS] = {0.03f, 0.12f, 0.4135f, 1.0f, 5.00f};
     for (int variant = 0; variant < PALETTE_VARIANTS; variant++) {
-        for (int i = 0; i < PALETTE_COLORS; i++) {
-            Color c = base_palette[i];
-            // Always apply factor; palette 3 uses 1.00 so it's identical to base
-            c.r = apply_brightness(base_palette[i].r, factors[variant]);
-            c.g = apply_brightness(base_palette[i].g, factors[variant]);
-            c.b = apply_brightness(base_palette[i].b, factors[variant]);
-            c.term256 = rgb_to_ansi256(c.r, c.g, c.b);
-            palettes[variant][i] = c;
-        }
+        rebuild_palette_variant(variant);
     }
     initialized = 1;
 }
@@ -301,6 +313,24 @@ static void set_current_palette_variant(int variant) {
     if (variant < 0) variant = 0;
     if (variant >= PALETTE_VARIANTS) variant = PALETTE_VARIANTS - 1;
     current_palette_variant = variant;
+}
+
+static void reset_palette_variant_brightness(int variant) {
+    init_palettes();
+    if (variant < 0 || variant >= PALETTE_VARIANTS) return;
+    palette_brightness_offsets[variant] = 0.0f;
+    rebuild_palette_variant(variant);
+}
+
+static void adjust_current_palette_brightness(float delta) {
+    init_palettes();
+    int variant = current_palette_variant;
+    if (variant < 0 || variant >= PALETTE_VARIANTS) return;
+    palette_brightness_offsets[variant] += delta;
+    float factor = palette_base_factors[variant] + palette_brightness_offsets[variant];
+    factor = clamp_brightness_factor(factor);
+    palette_brightness_offsets[variant] = factor - palette_base_factors[variant];
+    rebuild_palette_variant(variant);
 }
 
 /* -------- Undo/Redo -------- */
@@ -839,23 +869,36 @@ static int handle_key_event(int key, int *running) {
             break;
 
         case '1':
+            reset_palette_variant_brightness(0);
             set_current_palette_variant(0);
             need_render = 1;
             break;
         case '2':
+            reset_palette_variant_brightness(1);
             set_current_palette_variant(1);
             need_render = 1;
             break;
         case '3':
+            reset_palette_variant_brightness(2);
             set_current_palette_variant(2);
             need_render = 1;
             break;
         case '4':
+            reset_palette_variant_brightness(3);
             set_current_palette_variant(3);
             need_render = 1;
             break;
         case '5':
+            reset_palette_variant_brightness(4);
             set_current_palette_variant(4);
+            need_render = 1;
+            break;
+        case '+':
+            adjust_current_palette_brightness(0.10f);
+            need_render = 1;
+            break;
+        case '-':
+            adjust_current_palette_brightness(-0.10f);
             need_render = 1;
             break;
 
@@ -986,7 +1029,8 @@ static int build_status_lines(int cols, char lines[][256], int max_lines) {
     const char *shortcuts[] = {
         "Draw:A-Z",
         "Fill:^F+Color",
-        "Brightness:^1-^5",
+        "Palette:1-5",
+        "Brightness:+/-",
         "Erase:Backspace/Delete",
         "Resize:^R",
         "Select:^T",


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to temporarily increase or decrease the brightness of the currently selected palette so more usable colors are available beyond the defaults.
- Ensure that choosing a palette via `1`–`5` resets that palette to its default brightness so temporary adjustments can be undone by re-selecting the palette number.

### Description
- Added per-variant base factors and `palette_brightness_offsets[]` state and a `clamp_brightness_factor` helper so adjustments are bounded (`0.01`..`8.0`).
- Introduced `rebuild_palette_variant`, `reset_palette_variant_brightness`, and `adjust_current_palette_brightness` to rebuild palette entries when brightness changes and to isolate adjustments to the current palette variant.
- Updated `init_palettes` to use `rebuild_palette_variant` and replaced the hard-coded factors array with `palette_base_factors` so offsets layer on top of defaults.
- Mapped `+` and `-` keys to call `adjust_current_palette_brightness(±0.10f)`, and modified `1`–`5` handling to call `reset_palette_variant_brightness` before activating a palette; updated status/help text and top-file feature comment accordingly.

### Testing
- Ran `make clean all` from the repo root and the full project build completed successfully under strict flags (`-Wall -Wextra -Werror -Wpedantic`).
- Verified `apps/paint.c` compiled and linked cleanly as part of the build with no warnings or errors.
- Build output still includes the existing environment warning from `./budo/build.sh` about missing SDL2 development files, but that warning is unrelated and the automated build finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ca70e3448327b3e19b131863f51e)