### PR TITLE
Expose TERM-active flag to TASKs: add `_TERM_ACTIVE` and set `BUDOSTACK_TERM_ACTIVE` in terminal spawn

### DIFF
--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -7105,9 +7105,11 @@ static pid_t spawn_budostack(const char *exe_path, int *out_master_fd) {
         close(master_fd);
 
         const char *term_value = getenv("TERM");
-        if (!term_value || term_value[0] == '\0') {
+        if (!term_value || term_value[0] == ' ') {
             setenv("TERM", "xterm-256color", 1);
         }
+
+        setenv("BUDOSTACK_TERM_ACTIVE", "TRUE", 1);
 
         execl(exe_path, exe_path, (char *)NULL);
         perror("execl");

--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -7105,7 +7105,7 @@ static pid_t spawn_budostack(const char *exe_path, int *out_master_fd) {
         close(master_fd);
 
         const char *term_value = getenv("TERM");
-        if (!term_value || term_value[0] == ' ') {
+        if (!term_value || term_value[0] == '\0') {
             setenv("TERM", "xterm-256color", 1);
         }
 

--- a/commands/_TERM_ACTIVE.c
+++ b/commands/_TERM_ACTIVE.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void print_usage(void) {
+    printf("_TERM_ACTIVE\n");
+    printf("Prints 1 when running inside ./apps/terminal, otherwise 0.\n");
+}
+
+int main(int argc, char **argv) {
+    if (argc > 1 && (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)) {
+        print_usage();
+        return EXIT_SUCCESS;
+    }
+
+    const char *state = getenv("BUDOSTACK_TERM_ACTIVE");
+    if (state && strcmp(state, "TRUE") == 0) {
+        printf("1\n");
+    } else {
+        printf("0\n");
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/commands/manual.md
+++ b/commands/manual.md
@@ -193,6 +193,12 @@ Layer 1 is topmost; default layer is 1.
 **Description:** Enables (`enable`) or disables (`disable`) the blinking text cursor
 in the terminal emulator. When disabled, the cursor is hidden.
 
+### `_TERM_ACTIVE`
+**Usage:** `_TERM_ACTIVE`
+
+**Description:** Prints `1` when TASK scripts are running inside `./apps/terminal`.
+Prints `0` when running in a plain Linux terminal.
+
 ### `_TERM_KEYBOARD`
 **Usage:** `_TERM_KEYBOARD`
 

--- a/documents/help.txt
+++ b/documents/help.txt
@@ -220,6 +220,7 @@
   _RETROPROFILE        : List/show/apply/reset retro color profiles.
   _TERM_CLEAN          : Clear pixel rectangle area from terminal render layer.
   _TERM_CURSOR_BLINK   : Enable or disable blinking cursor in terminal.
+  _TERM_ACTIVE         : Print 1 in apps/terminal, else 0.
   _TERM_KEYBOARD       : Read buffered key events as TASK array literal.
   _TERM_MARGIN         : Set terminal pixel render margin.
   _TERM_MOUSE          : Read mouse X/Y and left/right button counters.

--- a/tasks/autoexec.task
+++ b/tasks/autoexec.task
@@ -88,17 +88,20 @@ IF ($LOAD < 100):
   GOTO LOADING
 END
 
-# Display intro logo and play starting tune
+# Display intro logo and play starting tune only in apps/terminal
 
-RUN clear
-RUN _WAIT 50
-RUN _DISPLAY -x 18 -y 2 -file ../icon_logo.png
-RUN _TERM_SOUND_PLAY 1 ../sounds/static_orchard.mp3 90
-RUN _WAIT 8300
-RUN _TEXT -x 45 -y 10 -text "BUDOSTACK" -color 0
-RUN _TEXT -x 4 -y 42 -text "Created by: Ville Suoranta" -color 1
-RUN _TEXT -x 4 -y 43 -text "email: ville.m.suoranta(at)gmail.com"
-RUN _WAIT 4700
+RUN _TERM_ACTIVE TO $TERM_ACTIVE
+IF ($TERM_ACTIVE == "1"):
+  RUN clear
+  RUN _WAIT 50
+  RUN _DISPLAY -x 18 -y 2 -file ../icon_logo.png
+  RUN _TERM_SOUND_PLAY 1 ../sounds/static_orchard.mp3 90
+  RUN _WAIT 8300
+  RUN _TEXT -x 45 -y 10 -text "BUDOSTACK" -color 0
+  RUN _TEXT -x 4 -y 42 -text "Created by: Ville Suoranta" -color 1
+  RUN _TEXT -x 4 -y 43 -text "email: ville.m.suoranta(at)gmail.com"
+  RUN _WAIT 4700
+END
 
 #-------------------------------------------------------------------------
 # BUDOSTACK LAUNCHER


### PR DESCRIPTION
### Motivation
- Allow TASK scripts to detect when they are running inside the built-in terminal emulator vs a plain Linux terminal so terminal-specific UI (intro/logo) can be conditionally shown.
- Add a lightweight command to query that state from TASK scripts.

### Description
- Set the environment variable `BUDOSTACK_TERM_ACTIVE=TRUE` when spawning the terminal child process in `apps/terminal.c`.
- Add a new command binary `commands/_TERM_ACTIVE.c` that prints `1` when `BUDOSTACK_TERM_ACTIVE` is `TRUE` and `0` otherwise and includes a `-h/--help` usage option.
- Document the new command in `commands/manual.md` and `documents/help.txt` and update `tasks/autoexec.task` to use `_TERM_ACTIVE` to conditionally display the intro/logo only when running inside `./apps/terminal`.

### Testing
- Built the project with `make` which completed successfully.
- Ran the new command binary directly with and without the `BUDOSTACK_TERM_ACTIVE` environment variable set, asserting it prints `1` when set and `0` when unset, and those checks passed.
- Rebuilt and ran the TASK script changes (via the automated build) to ensure there were no compile errors and the updated `autoexec.task` logic compiles, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a143228d96c832792635979b0b9aae7)