### PR TITLE
Add `_RAND` command and implement C64-style intro loading noise

### DIFF
--- a/commands/_RAND.c
+++ b/commands/_RAND.c
@@ -1,0 +1,83 @@
+#define _POSIX_C_SOURCE 200809L
+#define _XOPEN_SOURCE 700
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+static int parse_long(const char *text, const char *label, long *out_value) {
+    char *endptr = NULL;
+
+    if (text == NULL || label == NULL || out_value == NULL) {
+        fprintf(stderr, "_RAND: internal parser error\n");
+        return -1;
+    }
+
+    errno = 0;
+    long parsed = strtol(text, &endptr, 10);
+
+    if (errno != 0 || endptr == text || *endptr != '\0') {
+        fprintf(stderr, "_RAND: invalid integer for %s: '%s'\n", label, text);
+        return -1;
+    }
+
+    *out_value = parsed;
+    return 0;
+}
+
+static unsigned long bounded_random(unsigned long range) {
+    unsigned long random_range = (unsigned long)RAND_MAX + 1UL;
+    unsigned long limit = random_range - (random_range % range);
+    unsigned long value = 0UL;
+
+    if (limit == 0UL) {
+        return (unsigned long)(rand() % (int)range);
+    }
+
+    do {
+        value = (unsigned long)rand();
+    } while (value >= limit);
+
+    return value % range;
+}
+
+int main(int argc, char *argv[]) {
+    long min = 0L;
+    long max = LONG_MAX;
+
+    if (argc == 1) {
+        min = 0L;
+        max = 100L;
+    } else if (argc == 3) {
+        if (parse_long(argv[1], "min", &min) != 0)
+            return EXIT_FAILURE;
+        if (parse_long(argv[2], "max", &max) != 0)
+            return EXIT_FAILURE;
+    } else {
+        fprintf(stderr, "Usage: _RAND [min max]\n");
+        return EXIT_FAILURE;
+    }
+
+    if (min > max) {
+        fprintf(stderr, "_RAND: min must be less than or equal to max\n");
+        return EXIT_FAILURE;
+    }
+
+    unsigned long seed = (unsigned long)time(NULL) ^ (unsigned long)getpid();
+    srand((unsigned int)seed);
+
+    if (min == max) {
+        printf("%ld\n", min);
+        return EXIT_SUCCESS;
+    }
+
+    unsigned long span = (unsigned long)(max - min) + 1UL;
+    long result = min + (long)bounded_random(span);
+
+    printf("%ld\n", result);
+    return EXIT_SUCCESS;
+}

--- a/commands/manual.md
+++ b/commands/manual.md
@@ -171,6 +171,12 @@ alphabetically.
 0–15 use the active retro palette; 16 is the default foreground, 17 is the default
 background, and 18 is the cursor highlight.
 
+### `_RAND`
+**Usage:** `_RAND [min max]`
+
+**Description:** Prints a random integer. With no arguments it prints a value in the
+range `0..100`. With `min max`, it prints a value in the inclusive range `min..max`.
+
 ### `_RETROPROFILE`
 **Usage:** `_RETROPROFILE <command> [profile]`
 

--- a/tasks/autoexec.task
+++ b/tasks/autoexec.task
@@ -94,7 +94,20 @@ IF ($TERM_ACTIVE == "1"):
   END
 
   # Implement 2 seconds of commodore 64 loading noise HERE
-  # TBD
+  # Draw random stripes to mimic C64 tape loading noise.
+  SET $NOISE_TICKS = 0
+  @C64_NOISE
+  RUN _RAND 0 74 TO $NOISE_X
+  RUN _RAND 0 42 TO $NOISE_Y
+  RUN _RAND 1 5 TO $NOISE_W
+  RUN _RAND 1 2 TO $NOISE_H
+  RUN _RAND 0 18 TO $NOISE_COLOR
+  RUN _RECT -x $NOISE_X -y $NOISE_Y -width $NOISE_W -height $NOISE_H -color $NOISE_COLOR -fill on
+  RUN _WAIT 25
+  SET $NOISE_TICKS = $NOISE_TICKS + 1
+  IF ($NOISE_TICKS < 80):
+    GOTO C64_NOISE
+  END
 
   # Display intro logo and play starting tune
   


### PR DESCRIPTION
### Motivation
- Provide a simple TASK-level random integer generator so TASK scripts can produce procedurally-placed noise visuals. 
- Implement the previously-TBD Commodore 64 cassette loading noise in the startup `INTRO` so the terminal intro has a short retro visual effect.

### Description
- Added a new command `commands/_RAND.c` that prints a random integer; with no arguments it returns `0..100`, and with `min max` it returns an inclusive `min..max` value, performing argument validation and using a time/pid seed for randomness.
- Replaced the `TBD` section in `tasks/autoexec.task` with a `C64_NOISE` loop that calls `RUN _RAND` to choose randomized `x`, `y`, `width`, `height`, and `color` and draws tiny filled rectangles via `RUN _RECT` for 80 ticks of 25ms (≈2 seconds total) to mimic C64 tape noise.
- Updated `commands/manual.md` to document the new `RAND` command usage and behavior.

### Testing
- Ran a full build from the repo root with `make clean all` and the build completed successfully with all commands linked and no compiler warnings or errors.
- The build output included a non-fatal `./budo/build.sh` warning about SDL2 detection, which is unrelated to these changes and did not affect compilation of the new command or modified TASK script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1460e73b8883278b017728453c89b7)