### PR TITLE
Prevent Alt+digit textinput from leaking into PTY during tab switch

### DIFF
--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -7720,6 +7720,7 @@ int main(int argc, char **argv) {
     const Uint32 cursor_blink_interval = TERMINAL_CURSOR_BLINK_INTERVAL;
     Uint32 cursor_last_toggle = SDL_GetTicks();
     int cursor_phase_visible = 1;
+    int suppress_textinput_once = 0;
 
     while (running) {
         terminal_selection_validate(buffer);
@@ -8053,6 +8054,7 @@ int main(int argc, char **argv) {
                         terminal_force_full_redraw = 1;
                         terminal_background_dirty = 1;
                     }
+                    suppress_textinput_once = 1;
                     continue;
                 }
 
@@ -8438,6 +8440,10 @@ int main(int argc, char **argv) {
                     continue;
                 }
             } else if (event.type == SDL_TEXTINPUT) {
+                if (suppress_textinput_once) {
+                    suppress_textinput_once = 0;
+                    continue;
+                }
                 terminal_input_draw_requested = 1;
                 const char *text = event.text.text;
                 size_t len = strlen(text);


### PR DESCRIPTION
### Motivation
- Prevent the stray `SDL_TEXTINPUT` character (seen as `^[X`) from being forwarded to the PTY when the user switches tabs with `Alt+1`..`Alt+5` so prompts waiting for input do not receive the digit.

### Description
- Add a one-shot `int suppress_textinput_once` flag in the SDL event loop in `apps/terminal.c`, set it when an `Alt+1..Alt+5` tab-switch is handled in the `SDL_KEYDOWN` branch, and consume the next `SDL_TEXTINPUT` event while clearing the flag so the digit is not sent to the PTY.

### Testing
- Ran the repository build pipeline with `make clean all`, which completed successfully and produced no compiler warnings or errors in the compiled targets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16003a97188327b154c4545f7e0bd0)