### PR TITLE
Keep terminal cursor visible when blink is disabled

### DIFF
--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -8508,8 +8508,7 @@ int main(int argc, char **argv) {
         size_t cursor_global_index = buffer->history_rows + buffer->cursor_row;
         int cursor_render_visible = (clamped_scroll_offset == 0u) &&
                                     buffer->cursor_visible &&
-                                    cursor_phase_visible &&
-                                    terminal_cursor_blink_enabled;
+                                    (!terminal_cursor_blink_enabled || cursor_phase_visible);
 
         size_t selection_start = 0u;
         size_t selection_end = 0u;


### PR DESCRIPTION
### Motivation
- Fix startup behavior where running `tasks/autoexec.task` (which issues `_TERM_CURSOR_BLINK disable`) made the text cursor invisible until later input activity, by treating a disabled blink as a solid visible cursor.

### Description
- Update `apps/terminal.c` so `cursor_render_visible` is true when blinking is disabled by changing the condition to `(!terminal_cursor_blink_enabled || cursor_phase_visible)` instead of requiring both `cursor_phase_visible` and `terminal_cursor_blink_enabled`.

### Testing
- Ran `make clean all` from the repo root and the build completed successfully (including building `budostack` and `apps/terminal`) with no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1898e3fcd8832787cb16d2767ce38e)