### PR TITLE
Add `_PIXEL` command and `tasks/graphics.task` demo

### DIFF
--- a/commands/_PIXEL.c
+++ b/commands/_PIXEL.c
@@ -1,0 +1,159 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../lib/retroprofile.h"
+#include "../lib/termbg.h"
+
+static int clamp_color_value(int value) {
+    if (value < 0)
+        return 0;
+    if (value > 18)
+        return 18;
+    return value;
+}
+
+static int retroprofile_color_from_index(int index, RetroColor *out_color) {
+    if (out_color == NULL)
+        return -1;
+
+    const RetroProfile *profile = retroprofile_active();
+    if (profile == NULL)
+        return -1;
+
+    if (index >= 0 && index < 16) {
+        *out_color = profile->colors[index];
+        return 0;
+    }
+
+    if (index == 16) {
+        *out_color = profile->defaults.foreground;
+        return 0;
+    }
+
+    if (index == 17) {
+        *out_color = profile->defaults.background;
+        return 0;
+    }
+
+    if (index == 18) {
+        *out_color = profile->defaults.cursor;
+        return 0;
+    }
+
+    return -1;
+}
+
+static int resolve_color(int color_index) {
+    int clamped = clamp_color_value(color_index);
+    RetroColor palette_color;
+    if (retroprofile_color_from_index(clamped, &palette_color) == 0)
+        return termbg_encode_truecolor(palette_color.r, palette_color.g, palette_color.b);
+    return clamped;
+}
+
+static void apply_background_sequence(int resolved_color) {
+    if (termbg_is_truecolor(resolved_color)) {
+        int r, g, b;
+        termbg_decode_truecolor(resolved_color, &r, &g, &b);
+        printf("\033[48;2;%d;%d;%dm", r, g, b);
+    } else {
+        printf("\033[48;5;%dm", resolved_color);
+    }
+}
+
+static int parse_int(const char *value, const char *name, int *out) {
+    char *endptr = NULL;
+    errno = 0;
+    long parsed = strtol(value, &endptr, 10);
+
+    if (errno != 0 || endptr == value || *endptr != '\0') {
+        fprintf(stderr, "_PIXEL: invalid integer for %s: '%s'\n", name, value);
+        return -1;
+    }
+
+    if (parsed < INT_MIN || parsed > INT_MAX) {
+        fprintf(stderr, "_PIXEL: integer out of range for %s: '%s'\n", name, value);
+        return -1;
+    }
+
+    *out = (int)parsed;
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+    int x = -1;
+    int y = -1;
+    int color = 16;
+
+    for (int i = 1; i < argc;) {
+        const char *arg = argv[i];
+
+        if (strcmp(arg, "-x") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "_PIXEL: missing value for -x\n");
+                return EXIT_FAILURE;
+            }
+            if (parse_int(argv[i + 1], "-x", &x) != 0)
+                return EXIT_FAILURE;
+            i += 2;
+        } else if (strcmp(arg, "-y") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "_PIXEL: missing value for -y\n");
+                return EXIT_FAILURE;
+            }
+            if (parse_int(argv[i + 1], "-y", &y) != 0)
+                return EXIT_FAILURE;
+            i += 2;
+        } else if (strcmp(arg, "-color") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "_PIXEL: missing value for -color\n");
+                return EXIT_FAILURE;
+            }
+            if (parse_int(argv[i + 1], "-color", &color) != 0)
+                return EXIT_FAILURE;
+            i += 2;
+        } else {
+            fprintf(stderr, "_PIXEL: unknown argument '%s'\n", arg);
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (x < 0 || y < 0) {
+        fprintf(stderr, "Usage: _PIXEL -x <col> -y <row> [-color <0-18>]\n");
+        return EXIT_FAILURE;
+    }
+
+    color = clamp_color_value(color);
+    int resolved_color = resolve_color(color);
+
+    int row = y + 1;
+    int col = x + 1;
+
+    if (row < 1)
+        row = 1;
+    if (col < 1)
+        col = 1;
+
+    printf("\033[%d;%dH", row, col);
+    apply_background_sequence(resolved_color);
+    printf(" ");
+    printf("\033[49m\033[39m");
+    if (fflush(stdout) == EOF) {
+        perror("_PIXEL: fflush");
+        termbg_shutdown();
+        return EXIT_FAILURE;
+    }
+
+    termbg_set(x, y, resolved_color);
+    if (termbg_save() != 0) {
+        fprintf(stderr, "_PIXEL: failed to save background state\n");
+        termbg_shutdown();
+        return EXIT_FAILURE;
+    }
+    termbg_shutdown();
+
+    return EXIT_SUCCESS;
+}

--- a/commands/manual.md
+++ b/commands/manual.md
@@ -171,6 +171,14 @@ alphabetically.
 0–15 use the active retro palette; 16 is the default foreground, 17 is the default
 background, and 18 is the cursor highlight.
 
+### `_PIXEL`
+**Usage:** `_PIXEL -x <col> -y <row> [-color <0-18>]`
+
+**Description:** Draws one background-color cell at the specified column/row. The
+default color is 16 when `-color` is omitted. Color indices 0–15 use the active
+retro palette; 16 is the default foreground, 17 is the default background, and 18
+is the cursor highlight.
+
 ### `_RAND`
 **Usage:** `_RAND [min max]`
 

--- a/tasks/graphics.task
+++ b/tasks/graphics.task
@@ -73,11 +73,12 @@ SET $CIRCLE_Y = { 4, 2, 1, 1, 0, 0, 0, 1, 1, 2, 4,
 FOR ($i=0; $i<LEN($CIRCLE_X); $i++):
   RUN _PIXEL -x 52+$CIRCLE_X[$i] -y 34+$CIRCLE_Y[$i] -color 13
 END
-RUN _TEXT -x 51 -y 39 -text "BUDO" -color 18
 
 RUN _TEXT -x 2 -y 47 -text "High-resolution canvas: 800x450 (about 100x56 text cells)." -color 16
 RUN _TEXT -x 2 -y 49 -text "Done: _PIXEL draws single colored cells, and _TEXT labels them." -color 16
 RUN _TEXT -x 2 -y 53 -text "Press any key (or Enter) to return to LOW resolution." -color 18
 SET $KEY = ""
 INPUT $KEY -wait off
+RUN cls
 RUN _TERM_RESOLUTION LOW
+

--- a/tasks/graphics.task
+++ b/tasks/graphics.task
@@ -1,7 +1,9 @@
 # graphics.task
 # Demonstrate text, points, lines, outlines, fills, symbols, and curves using
-# only _TEXT and _PIXEL for drawing.
+# only _TEXT and _PIXEL for drawing. Switch to the HIGH terminal resolution
+# first so the same terminal-cell pixels produce a finer 100x56 canvas.
 
+RUN _TERM_RESOLUTION HIGH
 RUN _CLEAR
 
 RUN _TEXT -x 2 -y 1 -text "PIXEL GRAPHICS DEMO" -color 18
@@ -73,4 +75,9 @@ FOR ($i=0; $i<LEN($CIRCLE_X); $i++):
 END
 RUN _TEXT -x 51 -y 39 -text "BUDO" -color 18
 
-RUN _TEXT -x 2 -y 47 -text "Done: _PIXEL draws single colored cells, and _TEXT labels them." -color 16
+RUN _TEXT -x 2 -y 47 -text "High-resolution canvas: 800x450 (about 100x56 text cells)." -color 16
+RUN _TEXT -x 2 -y 49 -text "Done: _PIXEL draws single colored cells, and _TEXT labels them." -color 16
+RUN _TEXT -x 2 -y 53 -text "Press any key (or Enter) to return to LOW resolution." -color 18
+SET $KEY = ""
+INPUT $KEY -wait off
+RUN _TERM_RESOLUTION LOW

--- a/tasks/graphics.task
+++ b/tasks/graphics.task
@@ -1,0 +1,76 @@
+# graphics.task
+# Demonstrate text, points, lines, outlines, fills, symbols, and curves using
+# only _TEXT and _PIXEL for drawing.
+
+RUN _CLEAR
+
+RUN _TEXT -x 2 -y 1 -text "PIXEL GRAPHICS DEMO" -color 18
+RUN _TEXT -x 2 -y 2 -text "Palette pixels 0-18" -color 16
+
+FOR ($c=0; $c<19; $c++):
+  RUN _PIXEL -x 3+$c -y 4 -color $c
+END
+
+RUN _TEXT -x 2 -y 6 -text "Horizontal and vertical lines" -color 16
+FOR ($x=3; $x<34; $x++):
+  RUN _PIXEL -x $x -y 8 -color 14
+END
+FOR ($y=8; $y<17; $y++):
+  RUN _PIXEL -x 3 -y $y -color 14
+END
+
+RUN _TEXT -x 39 -y 6 -text "Outline rectangle" -color 16
+FOR ($x=39; $x<66; $x++):
+  RUN _PIXEL -x $x -y 8 -color 10
+  RUN _PIXEL -x $x -y 16 -color 10
+END
+FOR ($y=8; $y<17; $y++):
+  RUN _PIXEL -x 39 -y $y -color 10
+  RUN _PIXEL -x 65 -y $y -color 10
+END
+
+RUN _TEXT -x 2 -y 18 -text "Filled block" -color 16
+FOR ($y=20; $y<27; $y++):
+  FOR ($x=3; $x<20; $x++):
+    RUN _PIXEL -x $x -y $y -color 4
+  END
+END
+RUN _TEXT -x 6 -y 23 -text "TEXT" -color 18
+
+RUN _TEXT -x 27 -y 18 -text "Diagonal cross" -color 16
+FOR ($i=0; $i<17; $i++):
+  RUN _PIXEL -x 29+$i -y 20+$i -color 12
+  RUN _PIXEL -x 45-$i -y 20+$i -color 12
+END
+
+RUN _TEXT -x 55 -y 18 -text "Triangle" -color 16
+FOR ($i=0; $i<10; $i++):
+  RUN _PIXEL -x 65-$i -y 20+$i -color 9
+  RUN _PIXEL -x 65+$i -y 20+$i -color 9
+END
+FOR ($x=56; $x<75; $x++):
+  RUN _PIXEL -x $x -y 29 -color 9
+END
+
+RUN _TEXT -x 2 -y 32 -text "Pixel curve / wave" -color 16
+SET $WAVE = { 4, 3, 2, 1, 1, 2, 3, 4,
+              5, 6, 7, 7, 6, 5, 4, 3,
+              2, 1, 1, 2, 3, 4, 5, 6,
+              7, 7, 6, 5, 4, 3, 2, 1 }
+FOR ($i=0; $i<LEN($WAVE); $i++):
+  RUN _PIXEL -x 4+$i -y 34+$WAVE[$i] -color 11
+END
+
+RUN _TEXT -x 43 -y 32 -text "Circle-ish point set" -color 16
+SET $CIRCLE_X = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                  10, 10, 9, 8, 7, 6, 5, 4, 3, 2,
+                  1, 0, 0, 0 }
+SET $CIRCLE_Y = { 4, 2, 1, 1, 0, 0, 0, 1, 1, 2, 4,
+                  5, 6, 8, 9, 9, 10, 10, 10, 9, 9,
+                  8, 6, 5, 4 }
+FOR ($i=0; $i<LEN($CIRCLE_X); $i++):
+  RUN _PIXEL -x 52+$CIRCLE_X[$i] -y 34+$CIRCLE_Y[$i] -color 13
+END
+RUN _TEXT -x 51 -y 39 -text "BUDO" -color 18
+
+RUN _TEXT -x 2 -y 47 -text "Done: _PIXEL draws single colored cells, and _TEXT labels them." -color 16


### PR DESCRIPTION
### Motivation
- Provide a lightweight point-drawing command to complement `_RECT`/`_TEXT` so TASK scripts can draw single background-color cells programmatically.
- Make it easy to demonstrate pixel-based drawings in the bundled TASK system with a self-contained example task.

### Description
- Add `commands/_PIXEL.c` implementing ` _PIXEL -x <col> -y <row> [-color <0-18>]` with argument parsing, clamping, retroprofile color resolution (including truecolor), terminal background escape emission, `termbg_set`, `termbg_save`, and robust error handling.
- Document the new command in `commands/manual.md` under `### _PIXEL` with usage and color semantics (default color `16`).
- Add `tasks/graphics.task` which demonstrates palette pixels 0–18, lines, outline rectangle, filled block, diagonals, triangle, wave, and a circle-like point set using only ` _PIXEL` and ` _TEXT`.

### Testing
- Ran `make clean all` from the repo root and the full build completed successfully; the optional `./budo/build.sh` step reported missing SDL2 dev files (warning) but the Make build continued and produced command binaries.
- Executed `BUDOSTACK_BG_STATE="$tmp" ./commands/_PIXEL -x 0 -y 0` and verified the background state file was written as expected (succeeded).
- Ran `BUDOSTACK_BG_STATE="$tmp" ./apps/runtask tasks/graphics.task` and inspected the output to confirm the demo renders (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a189e71329483279dd434012deedae3)