### PR TITLE
Render login logo as terminal sprite and clear sprite canvas on exit

### DIFF
--- a/tasks/autoexec.task
+++ b/tasks/autoexec.task
@@ -97,7 +97,8 @@ IF ($TERM_ACTIVE == "1"):
   
   RUN _CLEAR
   RUN _WAIT 50
-  RUN _DISPLAY -x 18 -y 2 -file ../icon_logo.png
+  RUN _TERM_SPRITE -x 195 -y 55 -file ./assets/login_logo.png -layer 16
+  RUN _TERM_RENDER -layer 16
   RUN _TERM_SOUND_PLAY 1 ../sounds/static_orchard.mp3 90
   RUN _WAIT 8300
   RUN _TEXT -x 45 -y 10 -text "BUDOSTACK" -color 0
@@ -113,6 +114,12 @@ END
 
 # Clear frame buffer
 RUN cls
+
+# Clear terminal sprite canvas after leaving the login screen
+FOR ($i=1;$i<17;$i++):
+  RUN _TERM_CLEAN -x 0 -y 0 -width 640 -height 360 -layer $i
+  RUN _TERM_RENDER -layer $i
+END
 
 # Login menu behavior according to config.ini
 RUN _CONFIG -read LOGIN_MENU TO $LOGIN_MENU


### PR DESCRIPTION
### Motivation
- Replace the old `DISPLAY`-based intro with the terminal sprite system so the 250×250 `tasks/assets/login_logo.png` is drawn using the terminal's sprite layers and renderer.
- Ensure the terminal sprite canvas is fully cleared after the login screen exits so no leftover pixels remain when the launcher/menu runs.

### Description
- Modified `tasks/autoexec.task` to replace `RUN _DISPLAY -x 18 -y 2 -file ../icon_logo.png` with `RUN _TERM_SPRITE -x 195 -y 55 -file ./assets/login_logo.png -layer 16` and followed it with `RUN _TERM_RENDER -layer 16`, which centers the 250×250 image on the 640×360 canvas.
- Added a launcher-entry cleanup loop that iterates `FOR ($i=1;$i<17;$i++):` and runs `RUN _TERM_CLEAN -x 0 -y 0 -width 640 -height 360 -layer $i` then `RUN _TERM_RENDER -layer $i` to clear and render every sprite layer (1–16).
- All changes are confined to `tasks/autoexec.task` and use the `_TERM_SPRITE`, `_TERM_RENDER`, and `_TERM_CLEAN` capabilities.

### Testing
- Ran `make clean all` to build the project; compilation completed successfully with no errors.
- Performed a smoke test by invoking the sprite and clean commands from the `tasks` directory with `../commands/_TERM_SPRITE -x 195 -y 55 -file ./assets/login_logo.png -layer 16` and `../commands/_TERM_CLEAN -x 0 -y 0 -width 640 -height 360 -layer 16`, both of which executed without error.
- Ran a whitespace/check pass (`diff --check`) to ensure no trivial repository issues were introduced and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18a7b654708327ac8635c4cfcd19ed)