### PR TITLE
Accelerate TASK sprite/rect rendering: add termgfx backend, runtask intrinsics, and demo

### DIFF
--- a/apps/runtask.c
+++ b/apps/runtask.c
@@ -43,6 +43,8 @@
 #include <math.h>
 #include <sys/stat.h>
 
+#include "../lib/termgfx.h"
+
 #define MAX_VARIABLES 128
 #define MAX_LABELS 256
 #define MAX_FUNCTIONS 64
@@ -2631,6 +2633,341 @@ static void print_help(void) {
     printf("  gcc -std=c11 -Wall -Wextra -Werror -Wpedantic -O2 -o runtask apps/runtask.c\n\n");
 }
 
+
+typedef enum {
+    TASK_TERM_BUILTIN_ERROR = -1,
+    TASK_TERM_BUILTIN_NOT_HANDLED = 0,
+    TASK_TERM_BUILTIN_HANDLED = 1
+} TaskTermBuiltinResult;
+
+static bool task_parse_long_arg(const char *arg, const char *name, long min_value, long max_value, long *out_value,
+                                int line) {
+    if (!arg || !out_value) {
+        return false;
+    }
+
+    char *endptr = NULL;
+    errno = 0;
+    long value = strtol(arg, &endptr, 10);
+    if (errno != 0 || endptr == arg || *endptr != '\0') {
+        fprintf(stderr, "RUN: invalid integer for %s at line %d: '%s'\n", name, line, arg);
+        return false;
+    }
+    if (value < min_value || value > max_value) {
+        fprintf(stderr, "RUN: %s must be between %ld and %ld at line %d.\n", name, min_value, max_value, line);
+        return false;
+    }
+
+    *out_value = value;
+    return true;
+}
+
+static bool task_term_resolve_color(long color, long r, long g, long b, uint8_t *r_out, uint8_t *g_out,
+                                    uint8_t *b_out, int line) {
+    if (!r_out || !g_out || !b_out) {
+        return false;
+    }
+
+    if (r >= 0 && g >= 0 && b >= 0) {
+        *r_out = (uint8_t)r;
+        *g_out = (uint8_t)g;
+        *b_out = (uint8_t)b;
+        return true;
+    }
+
+    if (termgfx_color_from_index((int)color, r_out, g_out, b_out) != 0) {
+        fprintf(stderr, "RUN: failed to resolve _TERM color at line %d.\n", line);
+        return false;
+    }
+    return true;
+}
+
+static TaskTermBuiltinResult try_run_builtin_term_command(char **argv_heap, int argcnt, int line, int debug,
+                                                          bool capture_output, Variable *capture_var,
+                                                          const VariableRef *capture_ref) {
+    if (!argv_heap || argcnt <= 0 || !argv_heap[0]) {
+        return TASK_TERM_BUILTIN_NOT_HANDLED;
+    }
+
+    if (equals_ignore_case(argv_heap[0], "_TERM_SPRITE_LOAD")) {
+        const char *file = NULL;
+        for (int i = 1; i < argcnt; i++) {
+            if (strcmp(argv_heap[i], "-file") == 0) {
+                if (++i >= argcnt) {
+                    fprintf(stderr, "RUN: _TERM_SPRITE_LOAD missing value for -file at line %d.\n", line);
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+                file = argv_heap[i];
+            } else {
+                return TASK_TERM_BUILTIN_NOT_HANDLED;
+            }
+        }
+        if (!file) {
+            fprintf(stderr, "RUN: _TERM_SPRITE_LOAD missing -file at line %d.\n", line);
+            return TASK_TERM_BUILTIN_ERROR;
+        }
+
+        char *literal = NULL;
+        if (termgfx_sprite_load_literal(file, &literal) != 0) {
+            return TASK_TERM_BUILTIN_ERROR;
+        }
+
+        if (capture_output) {
+            if (!capture_var || !capture_ref) {
+                free(literal);
+                return TASK_TERM_BUILTIN_ERROR;
+            }
+            Value value;
+            memset(&value, 0, sizeof(value));
+            if (!parse_value_from_string(literal, &value, line, debug)) {
+                value.type = VALUE_STRING;
+                value.str_val = literal;
+                value.owns_string = true;
+                literal = NULL;
+            }
+            bool ok = set_variable_from_ref(capture_var, capture_ref, &value);
+            free_value(&value);
+            free(literal);
+            if (!ok) {
+                return TASK_TERM_BUILTIN_ERROR;
+            }
+        } else {
+            if (printf("%s\n", literal) < 0) {
+                perror("RUN: _TERM_SPRITE_LOAD printf");
+                free(literal);
+                return TASK_TERM_BUILTIN_ERROR;
+            }
+            free(literal);
+        }
+        if (debug) {
+            fprintf(stderr, "RUN: accelerated _TERM_SPRITE_LOAD\n");
+        }
+        return TASK_TERM_BUILTIN_HANDLED;
+    }
+
+    if (capture_output) {
+        return TASK_TERM_BUILTIN_NOT_HANDLED;
+    }
+
+    if (equals_ignore_case(argv_heap[0], "_TERM_SPRITE")) {
+        long origin_x = -1;
+        long origin_y = -1;
+        long layer = 1;
+        long width = -1;
+        long height = -1;
+        const char *file = NULL;
+        const char *sprite_literal = NULL;
+        const char *data = NULL;
+
+        for (int i = 1; i < argcnt; i++) {
+            if (strcmp(argv_heap[i], "-x") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-x", 0, INT_MAX, &origin_x, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-y") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-y", 0, INT_MAX, &origin_y, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-layer") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-layer", 1, 16, &layer, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-file") == 0) {
+                if (++i >= argcnt) {
+                    fprintf(stderr, "RUN: _TERM_SPRITE missing value for -file at line %d.\n", line);
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+                file = argv_heap[i];
+            } else if (strcmp(argv_heap[i], "-sprite") == 0) {
+                if (++i >= argcnt) {
+                    fprintf(stderr, "RUN: _TERM_SPRITE missing value for -sprite at line %d.\n", line);
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+                sprite_literal = argv_heap[i];
+            } else if (strcmp(argv_heap[i], "-data") == 0) {
+                if (++i >= argcnt) {
+                    fprintf(stderr, "RUN: _TERM_SPRITE missing value for -data at line %d.\n", line);
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+                data = argv_heap[i];
+            } else if (strcmp(argv_heap[i], "-width") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-width", 1, INT_MAX, &width, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-height") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-height", 1, INT_MAX, &height, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else {
+                return TASK_TERM_BUILTIN_NOT_HANDLED;
+            }
+        }
+
+        if (origin_x < 0 || origin_y < 0 || (file == NULL && sprite_literal == NULL && data == NULL)) {
+            fprintf(stderr, "RUN: _TERM_SPRITE missing required arguments at line %d.\n", line);
+            return TASK_TERM_BUILTIN_ERROR;
+        }
+        if ((file != NULL) + (sprite_literal != NULL) + (data != NULL) > 1) {
+            fprintf(stderr, "RUN: _TERM_SPRITE accepts only one of -file, -sprite, or -data at line %d.\n", line);
+            return TASK_TERM_BUILTIN_ERROR;
+        }
+
+        int rc;
+        if (sprite_literal) {
+            rc = termgfx_sprite_literal(origin_x, origin_y, sprite_literal, layer);
+        } else if (data) {
+            if (width <= 0 || height <= 0) {
+                fprintf(stderr, "RUN: _TERM_SPRITE -data requires -width and -height at line %d.\n", line);
+                return TASK_TERM_BUILTIN_ERROR;
+            }
+            rc = termgfx_sprite_data(origin_x, origin_y, width, height, data, layer);
+        } else {
+            rc = termgfx_sprite_file(origin_x, origin_y, file, layer);
+        }
+        if (debug) {
+            fprintf(stderr, "RUN: accelerated _TERM_SPRITE\n");
+        }
+        return rc == 0 ? TASK_TERM_BUILTIN_HANDLED : TASK_TERM_BUILTIN_ERROR;
+    }
+
+    if (equals_ignore_case(argv_heap[0], "_TERM_RENDER")) {
+        long layer = 0;
+        for (int i = 1; i < argcnt; i++) {
+            if (strcmp(argv_heap[i], "--render") == 0) {
+                continue;
+            }
+            if (strcmp(argv_heap[i], "-layer") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-layer", 1, 16, &layer, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+                continue;
+            }
+            return TASK_TERM_BUILTIN_NOT_HANDLED;
+        }
+        if (debug) {
+            fprintf(stderr, "RUN: accelerated _TERM_RENDER\n");
+        }
+        return termgfx_render(layer) == 0 ? TASK_TERM_BUILTIN_HANDLED : TASK_TERM_BUILTIN_ERROR;
+    }
+
+    if (equals_ignore_case(argv_heap[0], "_TERM_CLEAN")) {
+        long x = -1;
+        long y = -1;
+        long width = -1;
+        long height = -1;
+        long layer = 1;
+        for (int i = 1; i < argcnt; i++) {
+            if (strcmp(argv_heap[i], "-x") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-x", 0, INT_MAX, &x, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-y") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-y", 0, INT_MAX, &y, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-width") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-width", 1, INT_MAX, &width, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-height") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-height", 1, INT_MAX, &height, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-layer") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-layer", 1, 16, &layer, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else {
+                return TASK_TERM_BUILTIN_NOT_HANDLED;
+            }
+        }
+        if (x < 0 || y < 0 || width <= 0 || height <= 0) {
+            fprintf(stderr, "RUN: _TERM_CLEAN missing geometry at line %d.\n", line);
+            return TASK_TERM_BUILTIN_ERROR;
+        }
+        if (debug) {
+            fprintf(stderr, "RUN: accelerated _TERM_CLEAN\n");
+        }
+        return termgfx_clear(x, y, width, height, layer) == 0 ? TASK_TERM_BUILTIN_HANDLED : TASK_TERM_BUILTIN_ERROR;
+    }
+
+    if (equals_ignore_case(argv_heap[0], "_TERM_PIXEL") || equals_ignore_case(argv_heap[0], "_TERM_RECT")) {
+        bool is_rect = equals_ignore_case(argv_heap[0], "_TERM_RECT");
+        long x = -1;
+        long y = -1;
+        long width = -1;
+        long height = -1;
+        long layer = 1;
+        long color = 16;
+        long r = -1;
+        long g = -1;
+        long b = -1;
+
+        for (int i = 1; i < argcnt; i++) {
+            if (strcmp(argv_heap[i], "-x") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-x", 0, INT_MAX, &x, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-y") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-y", 0, INT_MAX, &y, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-width") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-width", 1, INT_MAX, &width, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-height") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-height", 1, INT_MAX, &height, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-layer") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-layer", 1, 16, &layer, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+            } else if (strcmp(argv_heap[i], "-color") == 0) {
+                if (++i >= argcnt || !task_parse_long_arg(argv_heap[i], "-color", 0, 18, &color, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+                r = -1;
+                g = -1;
+                b = -1;
+            } else if (strcmp(argv_heap[i], "-rgb") == 0) {
+                if (i + 3 >= argcnt ||
+                    !task_parse_long_arg(argv_heap[i + 1], "red", 0, 255, &r, line) ||
+                    !task_parse_long_arg(argv_heap[i + 2], "green", 0, 255, &g, line) ||
+                    !task_parse_long_arg(argv_heap[i + 3], "blue", 0, 255, &b, line)) {
+                    return TASK_TERM_BUILTIN_ERROR;
+                }
+                i += 3;
+            } else {
+                return TASK_TERM_BUILTIN_NOT_HANDLED;
+            }
+        }
+
+        if (x < 0 || y < 0 || (is_rect && (width <= 0 || height <= 0))) {
+            fprintf(stderr, "RUN: %s missing required geometry at line %d.\n", is_rect ? "_TERM_RECT" : "_TERM_PIXEL", line);
+            return TASK_TERM_BUILTIN_ERROR;
+        }
+
+        uint8_t rr = 0;
+        uint8_t gg = 0;
+        uint8_t bb = 0;
+        if (!task_term_resolve_color(color, r, g, b, &rr, &gg, &bb, line)) {
+            return TASK_TERM_BUILTIN_ERROR;
+        }
+
+        if (debug) {
+            fprintf(stderr, "RUN: accelerated %s\n", is_rect ? "_TERM_RECT" : "_TERM_PIXEL");
+        }
+        if (is_rect) {
+            return termgfx_rect(x, y, width, height, rr, gg, bb, layer) == 0 ? TASK_TERM_BUILTIN_HANDLED : TASK_TERM_BUILTIN_ERROR;
+        }
+        return termgfx_pixel(x, y, rr, gg, bb, layer) == 0 ? TASK_TERM_BUILTIN_HANDLED : TASK_TERM_BUILTIN_ERROR;
+    }
+
+    return TASK_TERM_BUILTIN_NOT_HANDLED;
+}
+
 static char *trim(char *s) {
     while (isspace((unsigned char)*s)) s++;
     if (!*s) return s;
@@ -4990,6 +5327,19 @@ int main(int argc, char *argv[]) {
                     fprintf(stderr, "Usage: _TOFILE -file <path> --start | _TOFILE --stop\n");
                 }
 
+                free_argv(argv_heap);
+                note_branch_progress(if_stack, &if_sp);
+                continue;
+            }
+
+            TaskTermBuiltinResult term_builtin_result = try_run_builtin_term_command(argv_heap,
+                                                                                     argcnt,
+                                                                                     script[pc].source_line,
+                                                                                     debug,
+                                                                                     capture_output,
+                                                                                     capture_var,
+                                                                                     &capture_ref);
+            if (term_builtin_result != TASK_TERM_BUILTIN_NOT_HANDLED) {
                 free_argv(argv_heap);
                 note_branch_progress(if_stack, &if_sp);
                 continue;

--- a/apps/terminal.c
+++ b/apps/terminal.c
@@ -427,6 +427,7 @@ static int terminal_custom_pixels_clear_rect(int origin_x, int origin_y, int wid
 static void terminal_custom_pixels_apply(uint8_t *framebuffer, int width, int height);
 static int terminal_custom_pixels_reserve(size_t additional);
 static int terminal_custom_pixels_draw_sprite(int origin_x, int origin_y, const uint8_t *rgba, int width, int height, uint8_t layer);
+static int terminal_custom_pixels_draw_rect(int origin_x, int origin_y, int width, int height, uint8_t r, uint8_t g, uint8_t b, uint8_t layer);
 static uint16_t terminal_custom_layer_mask(uint8_t layer);
 static void terminal_custom_pixels_mark_pending(uint8_t layer);
 static int terminal_custom_pixels_apply_pending_clears(uint8_t layer);
@@ -2084,6 +2085,49 @@ static int terminal_custom_pixels_set(int x, int y, uint8_t r, uint8_t g, uint8_
     entry->layer = layer;
     entry->version = terminal_custom_layer_versions[layer];
     terminal_custom_pixels_mark_pending(layer);
+    return 0;
+}
+
+static int terminal_custom_pixels_draw_rect(int origin_x, int origin_y, int width, int height, uint8_t r, uint8_t g, uint8_t b, uint8_t layer) {
+    if (width <= 0 || height <= 0) {
+        return -1;
+    }
+    if (origin_x < 0 || origin_y < 0) {
+        return -1;
+    }
+    if (layer < 1u || layer > 16u) {
+        return -1;
+    }
+    if (width > INT_MAX - origin_x || height > INT_MAX - origin_y) {
+        return -1;
+    }
+
+    size_t width_sz = (size_t)width;
+    size_t height_sz = (size_t)height;
+    if (width_sz != 0u && height_sz > SIZE_MAX / width_sz) {
+        return -1;
+    }
+
+    size_t pixel_count = width_sz * height_sz;
+    if (terminal_custom_pixels_reserve(pixel_count) != 0) {
+        return -1;
+    }
+
+    for (int y = 0; y < height; y++) {
+        for (int x = 0; x < width; x++) {
+            struct terminal_custom_pixel *entry = &terminal_custom_pixels[terminal_custom_pixel_count++];
+            entry->x = origin_x + x;
+            entry->y = origin_y + y;
+            entry->r = r;
+            entry->g = g;
+            entry->b = b;
+            entry->layer = layer;
+            entry->version = terminal_custom_layer_versions[layer];
+        }
+    }
+
+    terminal_custom_pixels_mark_pending(layer);
+    terminal_custom_pixels_active = 1;
     return 0;
 }
 
@@ -5605,7 +5649,8 @@ static void terminal_handle_osc_777(struct terminal_buffer *buffer, const char *
                 TERMINAL_PIXEL_ACTION_NONE = 0,
                 TERMINAL_PIXEL_ACTION_DRAW = 1,
                 TERMINAL_PIXEL_ACTION_CLEAR = 2,
-                TERMINAL_PIXEL_ACTION_RENDER = 3
+                TERMINAL_PIXEL_ACTION_RENDER = 3,
+                TERMINAL_PIXEL_ACTION_RECT = 4
             };
             enum terminal_pixel_action pixel_action = TERMINAL_PIXEL_ACTION_NONE;
             enum terminal_sprite_action {
@@ -5624,6 +5669,8 @@ static void terminal_handle_osc_777(struct terminal_buffer *buffer, const char *
             long pixel_r = -1;
             long pixel_g = -1;
             long pixel_b = -1;
+            long pixel_w = -1;
+            long pixel_h = -1;
             long pixel_layer = 0;
             long sprite_x = -1;
             long sprite_y = -1;
@@ -5752,6 +5799,8 @@ static void terminal_handle_osc_777(struct terminal_buffer *buffer, const char *
                             pixel_action = TERMINAL_PIXEL_ACTION_CLEAR;
                         } else if (strcmp(value, "render") == 0) {
                             pixel_action = TERMINAL_PIXEL_ACTION_RENDER;
+                        } else if (strcmp(value, "rect") == 0) {
+                            pixel_action = TERMINAL_PIXEL_ACTION_RECT;
                         }
                     } else if (strcmp(key, "pixel_x") == 0 && value && *value != '\0') {
                         char *endptr = NULL;
@@ -5787,6 +5836,20 @@ static void terminal_handle_osc_777(struct terminal_buffer *buffer, const char *
                         long parsed = strtol(value, &endptr, 10);
                         if (errno == 0 && endptr && *endptr == '\0') {
                             pixel_b = parsed;
+                        }
+                    } else if (strcmp(key, "pixel_w") == 0 && value && *value != '\0') {
+                        char *endptr = NULL;
+                        errno = 0;
+                        long parsed = strtol(value, &endptr, 10);
+                        if (errno == 0 && endptr && *endptr == '\0') {
+                            pixel_w = parsed;
+                        }
+                    } else if (strcmp(key, "pixel_h") == 0 && value && *value != '\0') {
+                        char *endptr = NULL;
+                        errno = 0;
+                        long parsed = strtol(value, &endptr, 10);
+                        if (errno == 0 && endptr && *endptr == '\0') {
+                            pixel_h = parsed;
                         }
                     } else if (strcmp(key, "pixel_layer") == 0 && value && *value != '\0') {
                         char *endptr = NULL;
@@ -6047,11 +6110,28 @@ static void terminal_handle_osc_777(struct terminal_buffer *buffer, const char *
                                                    (uint8_t)pixel_r,
                                                    (uint8_t)pixel_g,
                                                    (uint8_t)pixel_b,
-                                                   1u) != 0) {
+                                                   (uint8_t)((pixel_layer >= 1 && pixel_layer <= 16) ? pixel_layer : 1)) != 0) {
                         fprintf(stderr, "terminal: Failed to draw custom pixel.\n");
                     }
                 } else {
                     fprintf(stderr, "terminal: Invalid pixel draw parameters.\n");
+                }
+            } else if (pixel_action == TERMINAL_PIXEL_ACTION_RECT) {
+                if (pixel_x >= 0 && pixel_y >= 0 && pixel_x <= INT_MAX && pixel_y <= INT_MAX &&
+                    pixel_w > 0 && pixel_h > 0 && pixel_w <= INT_MAX && pixel_h <= INT_MAX &&
+                    pixel_r >= 0 && pixel_r <= 255 && pixel_g >= 0 && pixel_g <= 255 && pixel_b >= 0 && pixel_b <= 255) {
+                    if (terminal_custom_pixels_draw_rect((int)pixel_x,
+                                                         (int)pixel_y,
+                                                         (int)pixel_w,
+                                                         (int)pixel_h,
+                                                         (uint8_t)pixel_r,
+                                                         (uint8_t)pixel_g,
+                                                         (uint8_t)pixel_b,
+                                                         (uint8_t)((pixel_layer >= 1 && pixel_layer <= 16) ? pixel_layer : 1)) != 0) {
+                        fprintf(stderr, "terminal: Failed to draw custom rectangle.\n");
+                    }
+                } else {
+                    fprintf(stderr, "terminal: Invalid pixel rectangle parameters.\n");
                 }
             } else if (pixel_action == TERMINAL_PIXEL_ACTION_CLEAR) {
                 terminal_custom_pixels_clear();

--- a/commands/_TERM_PIXEL.c
+++ b/commands/_TERM_PIXEL.c
@@ -1,0 +1,110 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../lib/termgfx.h"
+
+static void print_usage(void) {
+    fprintf(stderr,
+            "Usage: _TERM_PIXEL -x <pixels> -y <pixels> [-color <0-18> | -rgb <r> <g> <b>] [-layer <1-16>]\n");
+    fprintf(stderr, "  Queues one pixel on the BUDOSTACK terminal pixel surface. Use _TERM_RENDER to present it.\n");
+}
+
+static int parse_long(const char *arg, const char *name, long min_value, long max_value, long *out_value) {
+    if (!arg || !out_value) {
+        return -1;
+    }
+
+    char *endptr = NULL;
+    errno = 0;
+    long value = strtol(arg, &endptr, 10);
+    if (errno != 0 || endptr == arg || *endptr != '\0') {
+        fprintf(stderr, "_TERM_PIXEL: invalid integer for %s: '%s'\n", name, arg);
+        return -1;
+    }
+
+    if (value < min_value || value > max_value) {
+        fprintf(stderr, "_TERM_PIXEL: %s must be between %ld and %ld.\n", name, min_value, max_value);
+        return -1;
+    }
+
+    *out_value = value;
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    long x = -1;
+    long y = -1;
+    long layer = 1;
+    long color = 16;
+    long r = -1;
+    long g = -1;
+    long b = -1;
+
+    for (int i = 1; i < argc; i++) {
+        const char *arg = argv[i];
+        if (strcmp(arg, "-x") == 0) {
+            if (++i >= argc || parse_long(argv[i], "-x", 0, INT_MAX, &x) != 0) {
+                return EXIT_FAILURE;
+            }
+        } else if (strcmp(arg, "-y") == 0) {
+            if (++i >= argc || parse_long(argv[i], "-y", 0, INT_MAX, &y) != 0) {
+                return EXIT_FAILURE;
+            }
+        } else if (strcmp(arg, "-layer") == 0) {
+            if (++i >= argc || parse_long(argv[i], "-layer", 1, 16, &layer) != 0) {
+                return EXIT_FAILURE;
+            }
+        } else if (strcmp(arg, "-color") == 0) {
+            if (++i >= argc || parse_long(argv[i], "-color", 0, 18, &color) != 0) {
+                return EXIT_FAILURE;
+            }
+            r = -1;
+            g = -1;
+            b = -1;
+        } else if (strcmp(arg, "-rgb") == 0) {
+            if (i + 3 >= argc ||
+                parse_long(argv[i + 1], "red", 0, 255, &r) != 0 ||
+                parse_long(argv[i + 2], "green", 0, 255, &g) != 0 ||
+                parse_long(argv[i + 3], "blue", 0, 255, &b) != 0) {
+                return EXIT_FAILURE;
+            }
+            i += 3;
+        } else if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
+            print_usage();
+            return EXIT_SUCCESS;
+        } else {
+            fprintf(stderr, "_TERM_PIXEL: unknown argument '%s'.\n", arg);
+            print_usage();
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (x < 0 || y < 0) {
+        fprintf(stderr, "_TERM_PIXEL: missing required coordinates.\n");
+        print_usage();
+        return EXIT_FAILURE;
+    }
+
+    uint8_t rr = 0;
+    uint8_t gg = 0;
+    uint8_t bb = 0;
+    if (r >= 0 && g >= 0 && b >= 0) {
+        rr = (uint8_t)r;
+        gg = (uint8_t)g;
+        bb = (uint8_t)b;
+    } else if (termgfx_color_from_index((int)color, &rr, &gg, &bb) != 0) {
+        fprintf(stderr, "_TERM_PIXEL: failed to resolve color index.\n");
+        return EXIT_FAILURE;
+    }
+
+    if (termgfx_pixel(x, y, rr, gg, bb, layer) != 0) {
+        perror("_TERM_PIXEL");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/commands/_TERM_RECT.c
+++ b/commands/_TERM_RECT.c
@@ -1,0 +1,120 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../lib/termgfx.h"
+
+static void print_usage(void) {
+    fprintf(stderr,
+            "Usage: _TERM_RECT -x <pixels> -y <pixels> -width <pixels> -height <pixels> [-color <0-18> | -rgb <r> <g> <b>] [-layer <1-16>]\n");
+    fprintf(stderr, "  Queues a filled rectangle on the BUDOSTACK terminal pixel surface. Use _TERM_RENDER to present it.\n");
+}
+
+static int parse_long(const char *arg, const char *name, long min_value, long max_value, long *out_value) {
+    if (!arg || !out_value) {
+        return -1;
+    }
+
+    char *endptr = NULL;
+    errno = 0;
+    long value = strtol(arg, &endptr, 10);
+    if (errno != 0 || endptr == arg || *endptr != '\0') {
+        fprintf(stderr, "_TERM_RECT: invalid integer for %s: '%s'\n", name, arg);
+        return -1;
+    }
+
+    if (value < min_value || value > max_value) {
+        fprintf(stderr, "_TERM_RECT: %s must be between %ld and %ld.\n", name, min_value, max_value);
+        return -1;
+    }
+
+    *out_value = value;
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    long x = -1;
+    long y = -1;
+    long width = -1;
+    long height = -1;
+    long layer = 1;
+    long color = 16;
+    long r = -1;
+    long g = -1;
+    long b = -1;
+
+    for (int i = 1; i < argc; i++) {
+        const char *arg = argv[i];
+        if (strcmp(arg, "-x") == 0) {
+            if (++i >= argc || parse_long(argv[i], "-x", 0, INT_MAX, &x) != 0) {
+                return EXIT_FAILURE;
+            }
+        } else if (strcmp(arg, "-y") == 0) {
+            if (++i >= argc || parse_long(argv[i], "-y", 0, INT_MAX, &y) != 0) {
+                return EXIT_FAILURE;
+            }
+        } else if (strcmp(arg, "-width") == 0) {
+            if (++i >= argc || parse_long(argv[i], "-width", 1, INT_MAX, &width) != 0) {
+                return EXIT_FAILURE;
+            }
+        } else if (strcmp(arg, "-height") == 0) {
+            if (++i >= argc || parse_long(argv[i], "-height", 1, INT_MAX, &height) != 0) {
+                return EXIT_FAILURE;
+            }
+        } else if (strcmp(arg, "-layer") == 0) {
+            if (++i >= argc || parse_long(argv[i], "-layer", 1, 16, &layer) != 0) {
+                return EXIT_FAILURE;
+            }
+        } else if (strcmp(arg, "-color") == 0) {
+            if (++i >= argc || parse_long(argv[i], "-color", 0, 18, &color) != 0) {
+                return EXIT_FAILURE;
+            }
+            r = -1;
+            g = -1;
+            b = -1;
+        } else if (strcmp(arg, "-rgb") == 0) {
+            if (i + 3 >= argc ||
+                parse_long(argv[i + 1], "red", 0, 255, &r) != 0 ||
+                parse_long(argv[i + 2], "green", 0, 255, &g) != 0 ||
+                parse_long(argv[i + 3], "blue", 0, 255, &b) != 0) {
+                return EXIT_FAILURE;
+            }
+            i += 3;
+        } else if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
+            print_usage();
+            return EXIT_SUCCESS;
+        } else {
+            fprintf(stderr, "_TERM_RECT: unknown argument '%s'.\n", arg);
+            print_usage();
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (x < 0 || y < 0 || width <= 0 || height <= 0) {
+        fprintf(stderr, "_TERM_RECT: missing required geometry.\n");
+        print_usage();
+        return EXIT_FAILURE;
+    }
+
+    uint8_t rr = 0;
+    uint8_t gg = 0;
+    uint8_t bb = 0;
+    if (r >= 0 && g >= 0 && b >= 0) {
+        rr = (uint8_t)r;
+        gg = (uint8_t)g;
+        bb = (uint8_t)b;
+    } else if (termgfx_color_from_index((int)color, &rr, &gg, &bb) != 0) {
+        fprintf(stderr, "_TERM_RECT: failed to resolve color index.\n");
+        return EXIT_FAILURE;
+    }
+
+    if (termgfx_rect(x, y, width, height, rr, gg, bb, layer) != 0) {
+        perror("_TERM_RECT");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/commands/_TERM_SPRITE.c
+++ b/commands/_TERM_SPRITE.c
@@ -1,22 +1,19 @@
 #define _POSIX_C_SOURCE 200809L
 
-#include <ctype.h>
+#include "../lib/termgfx.h"
+
 #include <errno.h>
 #include <limits.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "../lib/stb_image.h"
-
 static void print_usage(void) {
     fprintf(stderr,
             "Usage: _TERM_SPRITE -x <pixels> -y <pixels> (-file <path> | -sprite {w,h,\"data\"} | -data <base64> -width <px> -height <px>) [-layer <1-16>]\n");
-    fprintf(stderr, "  Draws a PNG or BMP sprite onto the terminal's pixel surface.\n");
+    fprintf(stderr, "  Draws a PNG/BMP file, sprite literal, or raw base64 RGBA block onto the terminal pixel surface.\n");
     fprintf(stderr, "  Layers are numbered 1 (top) through 16 (bottom). Defaults to 1.\n");
-    fprintf(stderr, "  Use -sprite with the literal produced by _TERM_SPRITE_LOAD to avoid passing width/height separately.\n");
-    fprintf(stderr, "  The base64 payload may be quoted ({w,h,\"data\"}) or unquoted ({w,h,data}).\n");
+    fprintf(stderr, "  Use -sprite with the literal produced by _TERM_SPRITE_LOAD to avoid re-reading image files.\n");
 }
 
 static int parse_long(const char *arg, const char *name, long min_value, long max_value, long *out_value) {
@@ -31,7 +28,6 @@ static int parse_long(const char *arg, const char *name, long min_value, long ma
         fprintf(stderr, "_TERM_SPRITE: invalid integer for %s: '%s'\n", name, arg);
         return -1;
     }
-
     if (value < min_value || value > max_value) {
         fprintf(stderr, "_TERM_SPRITE: %s must be between %ld and %ld.\n", name, min_value, max_value);
         return -1;
@@ -41,186 +37,8 @@ static int parse_long(const char *arg, const char *name, long min_value, long ma
     return 0;
 }
 
-static size_t base64_encoded_size(size_t raw_size) {
-    if (raw_size == 0) {
-        return 0;
-    }
-    size_t rem = raw_size % 3u;
-    size_t blocks = raw_size / 3u;
-    size_t encoded = blocks * 4u;
-    if (rem > 0u) {
-        encoded += 4u;
-    }
-    return encoded;
-}
-
-static char base64_encode_table(int idx) {
-    static const char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    if (idx < 0 || idx >= 64) {
-        return '=';
-    }
-    return table[idx];
-}
-
-static int encode_base64(const uint8_t *data, size_t size, char *out, size_t out_size) {
-    if (!data || !out) {
-        return -1;
-    }
-    size_t required = base64_encoded_size(size);
-    if (out_size < required + 1u) {
-        return -1;
-    }
-
-    size_t out_idx = 0u;
-    for (size_t i = 0u; i + 2u < size; i += 3u) {
-        uint32_t block = ((uint32_t)data[i] << 16) | ((uint32_t)data[i + 1u] << 8) | (uint32_t)data[i + 2u];
-        out[out_idx++] = base64_encode_table((int)((block >> 18) & 0x3Fu));
-        out[out_idx++] = base64_encode_table((int)((block >> 12) & 0x3Fu));
-        out[out_idx++] = base64_encode_table((int)((block >> 6) & 0x3Fu));
-        out[out_idx++] = base64_encode_table((int)(block & 0x3Fu));
-    }
-
-    size_t remaining = size % 3u;
-    if (remaining == 1u) {
-        uint32_t block = ((uint32_t)data[size - 1u]) << 16;
-        out[out_idx++] = base64_encode_table((int)((block >> 18) & 0x3Fu));
-        out[out_idx++] = base64_encode_table((int)((block >> 12) & 0x3Fu));
-        out[out_idx++] = '=';
-        out[out_idx++] = '=';
-    } else if (remaining == 2u) {
-        uint32_t block = ((uint32_t)data[size - 2u] << 16) | ((uint32_t)data[size - 1u] << 8);
-        out[out_idx++] = base64_encode_table((int)((block >> 18) & 0x3Fu));
-        out[out_idx++] = base64_encode_table((int)((block >> 12) & 0x3Fu));
-        out[out_idx++] = base64_encode_table((int)((block >> 6) & 0x3Fu));
-        out[out_idx++] = '=';
-    }
-
-    out[out_idx] = '\0';
-    return 0;
-}
-
-static int parse_sprite_literal(const char *literal, int *width_out, int *height_out, char **data_out) {
-    if (!literal || !width_out || !height_out || !data_out) {
-        return -1;
-    }
-
-    const char *p = literal;
-    while (*p && isspace((unsigned char)*p)) {
-        ++p;
-    }
-
-    if (*p != '{') {
-        fprintf(stderr, "_TERM_SPRITE: sprite literal must start with '{'.\n");
-        return -1;
-    }
-    ++p;
-
-    while (*p && isspace((unsigned char)*p)) {
-        ++p;
-    }
-
-    errno = 0;
-    char *endptr = NULL;
-    long width = strtol(p, &endptr, 10);
-    if (errno != 0 || endptr == p || width <= 0 || width > INT_MAX) {
-        fprintf(stderr, "_TERM_SPRITE: invalid sprite width in literal.\n");
-        return -1;
-    }
-
-    p = endptr;
-    while (*p && isspace((unsigned char)*p)) {
-        ++p;
-    }
-    if (*p != ',') {
-        fprintf(stderr, "_TERM_SPRITE: sprite literal missing comma after width.\n");
-        return -1;
-    }
-    ++p;
-
-    while (*p && isspace((unsigned char)*p)) {
-        ++p;
-    }
-
-    errno = 0;
-    long height = strtol(p, &endptr, 10);
-    if (errno != 0 || endptr == p || height <= 0 || height > INT_MAX) {
-        fprintf(stderr, "_TERM_SPRITE: invalid sprite height in literal.\n");
-        return -1;
-    }
-
-    p = endptr;
-    while (*p && isspace((unsigned char)*p)) {
-        ++p;
-    }
-    if (*p != ',') {
-        fprintf(stderr, "_TERM_SPRITE: sprite literal missing comma after height.\n");
-        return -1;
-    }
-    ++p;
-
-    while (*p && isspace((unsigned char)*p)) {
-        ++p;
-    }
-    const char *data_start = NULL;
-    const char *data_end = NULL;
-    if (*p == '"') {
-        ++p;
-        data_start = p;
-        const char *closing_quote = strchr(data_start, '"');
-        if (!closing_quote) {
-            fprintf(stderr, "_TERM_SPRITE: sprite literal is missing the closing quote for data.\n");
-            return -1;
-        }
-        data_end = closing_quote;
-        p = closing_quote + 1;
-    } else {
-        data_start = p;
-        while (*p && !isspace((unsigned char)*p) && *p != '}') {
-            ++p;
-        }
-        data_end = p;
-    }
-
-    if (data_end == NULL || data_end <= data_start) {
-        fprintf(stderr, "_TERM_SPRITE: sprite literal must contain base64 data.\n");
-        return -1;
-    }
-
-    size_t data_len = (size_t)(data_end - data_start);
-    char *data_copy = malloc(data_len + 1u);
-    if (!data_copy) {
-        fprintf(stderr, "_TERM_SPRITE: failed to allocate memory for sprite data.\n");
-        return -1;
-    }
-    memcpy(data_copy, data_start, data_len);
-    data_copy[data_len] = '\0';
-
-    while (*p && isspace((unsigned char)*p)) {
-        ++p;
-    }
-    if (*p != '}') {
-        free(data_copy);
-        fprintf(stderr, "_TERM_SPRITE: sprite literal must end with '}'.\n");
-        return -1;
-    }
-    ++p;
-    while (*p && isspace((unsigned char)*p)) {
-        ++p;
-    }
-    if (*p != '\0') {
-        free(data_copy);
-        fprintf(stderr, "_TERM_SPRITE: unexpected characters after sprite literal.\n");
-        return -1;
-    }
-
-    *width_out = (int)width;
-    *height_out = (int)height;
-    *data_out = data_copy;
-    return 0;
-}
-
 int main(int argc, char **argv) {
-    if (argc < 2) {
+    if (argc == 1) {
         print_usage();
         return EXIT_FAILURE;
     }
@@ -228,8 +46,8 @@ int main(int argc, char **argv) {
     long origin_x = -1;
     long origin_y = -1;
     long layer = 1;
-    long width_arg = -1;
-    long height_arg = -1;
+    long width = -1;
+    long height = -1;
     const char *file = NULL;
     const char *data = NULL;
     const char *sprite_literal = NULL;
@@ -237,27 +55,15 @@ int main(int argc, char **argv) {
     for (int i = 1; i < argc; ++i) {
         const char *arg = argv[i];
         if (strcmp(arg, "-x") == 0) {
-            if (++i >= argc) {
-                fprintf(stderr, "_TERM_SPRITE: missing value for -x.\n");
-                return EXIT_FAILURE;
-            }
-            if (parse_long(argv[i], "-x", 0, INT_MAX, &origin_x) != 0) {
+            if (++i >= argc || parse_long(argv[i], "-x", 0, INT_MAX, &origin_x) != 0) {
                 return EXIT_FAILURE;
             }
         } else if (strcmp(arg, "-y") == 0) {
-            if (++i >= argc) {
-                fprintf(stderr, "_TERM_SPRITE: missing value for -y.\n");
-                return EXIT_FAILURE;
-            }
-            if (parse_long(argv[i], "-y", 0, INT_MAX, &origin_y) != 0) {
+            if (++i >= argc || parse_long(argv[i], "-y", 0, INT_MAX, &origin_y) != 0) {
                 return EXIT_FAILURE;
             }
         } else if (strcmp(arg, "-layer") == 0) {
-            if (++i >= argc) {
-                fprintf(stderr, "_TERM_SPRITE: missing value for -layer.\n");
-                return EXIT_FAILURE;
-            }
-            if (parse_long(argv[i], "-layer", 1, 16, &layer) != 0) {
+            if (++i >= argc || parse_long(argv[i], "-layer", 1, 16, &layer) != 0) {
                 return EXIT_FAILURE;
             }
         } else if (strcmp(arg, "-file") == 0) {
@@ -279,19 +85,11 @@ int main(int argc, char **argv) {
             }
             data = argv[i];
         } else if (strcmp(arg, "-width") == 0) {
-            if (++i >= argc) {
-                fprintf(stderr, "_TERM_SPRITE: missing value for -width.\n");
-                return EXIT_FAILURE;
-            }
-            if (parse_long(argv[i], "-width", 1, INT_MAX, &width_arg) != 0) {
+            if (++i >= argc || parse_long(argv[i], "-width", 1, INT_MAX, &width) != 0) {
                 return EXIT_FAILURE;
             }
         } else if (strcmp(arg, "-height") == 0) {
-            if (++i >= argc) {
-                fprintf(stderr, "_TERM_SPRITE: missing value for -height.\n");
-                return EXIT_FAILURE;
-            }
-            if (parse_long(argv[i], "-height", 1, INT_MAX, &height_arg) != 0) {
+            if (++i >= argc || parse_long(argv[i], "-height", 1, INT_MAX, &height) != 0) {
                 return EXIT_FAILURE;
             }
         } else {
@@ -306,107 +104,26 @@ int main(int argc, char **argv) {
         print_usage();
         return EXIT_FAILURE;
     }
-
     if ((file != NULL) + (data != NULL) + (sprite_literal != NULL) > 1) {
         fprintf(stderr, "_TERM_SPRITE: specify only one of -file, -sprite, or -data.\n");
         return EXIT_FAILURE;
     }
 
-    int width = 0;
-    int height = 0;
-    char *encoded = NULL;
-
-    if (sprite_literal != NULL) {
-        if (parse_sprite_literal(sprite_literal, &width, &height, &encoded) != 0) {
-            return EXIT_FAILURE;
-        }
-    } else if (data != NULL) {
-        if (width_arg <= 0 || height_arg <= 0) {
+    int rc;
+    if (sprite_literal) {
+        rc = termgfx_sprite_literal(origin_x, origin_y, sprite_literal, layer);
+    } else if (data) {
+        if (width <= 0 || height <= 0) {
             fprintf(stderr, "_TERM_SPRITE: -width and -height are required when using -data.\n");
             return EXIT_FAILURE;
         }
-        width = (int)width_arg;
-        height = (int)height_arg;
-        encoded = strdup(data);
-        if (!encoded) {
-            fprintf(stderr, "_TERM_SPRITE: failed to duplicate sprite data string.\n");
-            return EXIT_FAILURE;
-        }
+        rc = termgfx_sprite_data(origin_x, origin_y, width, height, data, layer);
     } else {
-        int channels = 0;
-        stbi_uc *pixels = stbi_load(file, &width, &height, &channels, 4);
-        if (!pixels) {
-            const char *reason = stbi_failure_reason();
-            if (reason && *reason) {
-                fprintf(stderr, "_TERM_SPRITE: failed to load '%s': %s\n", file, reason);
-            } else {
-                fprintf(stderr, "_TERM_SPRITE: failed to load '%s'\n", file);
-            }
-            return EXIT_FAILURE;
-        }
-
-        if (width <= 0 || height <= 0) {
-            stbi_image_free(pixels);
-            fprintf(stderr, "_TERM_SPRITE: invalid image dimensions in '%s'\n", file);
-            return EXIT_FAILURE;
-        }
-
-        size_t width_sz = (size_t)width;
-        size_t height_sz = (size_t)height;
-        if (width_sz != 0 && height_sz > SIZE_MAX / width_sz) {
-            stbi_image_free(pixels);
-            fprintf(stderr, "_TERM_SPRITE: image dimensions overflow.\n");
-            return EXIT_FAILURE;
-        }
-
-        size_t pixel_count = width_sz * height_sz;
-        if (pixel_count > SIZE_MAX / 4u) {
-            stbi_image_free(pixels);
-            fprintf(stderr, "_TERM_SPRITE: image too large to encode.\n");
-            return EXIT_FAILURE;
-        }
-
-        size_t raw_size = pixel_count * 4u;
-        size_t encoded_size = base64_encoded_size(raw_size);
-        if (encoded_size == 0 || encoded_size > SIZE_MAX - 1u) {
-            stbi_image_free(pixels);
-            fprintf(stderr, "_TERM_SPRITE: failed to compute encoded size.\n");
-            return EXIT_FAILURE;
-        }
-
-        encoded = malloc(encoded_size + 1u);
-        if (!encoded) {
-            stbi_image_free(pixels);
-            fprintf(stderr, "_TERM_SPRITE: failed to allocate %zu bytes for encoding.\n", encoded_size + 1u);
-            return EXIT_FAILURE;
-        }
-
-        int encode_status = encode_base64(pixels, raw_size, (char *)encoded, encoded_size + 1u);
-        stbi_image_free(pixels);
-        if (encode_status != 0) {
-            free(encoded);
-            fprintf(stderr, "_TERM_SPRITE: failed to encode image data.\n");
-            return EXIT_FAILURE;
-        }
+        rc = termgfx_sprite_file(origin_x, origin_y, file, layer);
     }
 
-    int print_status = printf("\x1b]777;sprite=draw;sprite_x=%ld;sprite_y=%ld;sprite_w=%d;sprite_h=%d;sprite_layer=%ld;sprite_data=%s\a",
-                              origin_x,
-                              origin_y,
-                              width,
-                              height,
-                              layer,
-                              encoded);
-    free(encoded);
-    if (print_status < 0) {
-        perror("_TERM_SPRITE: printf");
+    if (rc != 0) {
         return EXIT_FAILURE;
     }
-
-    if (fflush(stdout) != 0) {
-        perror("_TERM_SPRITE: fflush");
-        return EXIT_FAILURE;
-    }
-
     return EXIT_SUCCESS;
 }

--- a/commands/_TERM_SPRITE_LOAD.c
+++ b/commands/_TERM_SPRITE_LOAD.c
@@ -1,86 +1,21 @@
 #define _POSIX_C_SOURCE 200809L
 
-#include <stdint.h>
+#include "../lib/termgfx.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "../lib/stb_image.h"
-
 static void print_usage(void) {
     fprintf(stderr, "Usage: _TERM_SPRITE_LOAD -file <path>\n");
-    fprintf(stderr, "  Loads a PNG or BMP sprite and prints a TASK array literal\n");
-    fprintf(stderr, "  in the form {width,height,\"<base64 RGBA data>\"}.\n");
+    fprintf(stderr, "  Load a PNG/BMP file and print a reusable TASK sprite literal.\n");
     fprintf(stderr, "  Capture the output with `RUN _TERM_SPRITE_LOAD ... TO $VAR`\n");
-    fprintf(stderr, "  to reuse the sprite data without re-reading the file. Pass the\n");
-    fprintf(stderr, "  literal back to _TERM_SPRITE with -sprite for faster calls.\n");
-}
-
-static size_t base64_encoded_size(size_t raw_size) {
-    if (raw_size == 0) {
-        return 0;
-    }
-    size_t rem = raw_size % 3u;
-    size_t blocks = raw_size / 3u;
-    size_t encoded = blocks * 4u;
-    if (rem > 0u) {
-        encoded += 4u;
-    }
-    return encoded;
-}
-
-static char base64_encode_table(int idx) {
-    static const char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    if (idx < 0 || idx >= 64) {
-        return '=';
-    }
-    return table[idx];
-}
-
-static int encode_base64(const uint8_t *data, size_t size, char *out, size_t out_size) {
-    if (!data || !out) {
-        return -1;
-    }
-    size_t required = base64_encoded_size(size);
-    if (out_size < required + 1u) {
-        return -1;
-    }
-
-    size_t out_idx = 0u;
-    for (size_t i = 0u; i + 2u < size; i += 3u) {
-        uint32_t block = ((uint32_t)data[i] << 16) | ((uint32_t)data[i + 1u] << 8) | (uint32_t)data[i + 2u];
-        out[out_idx++] = base64_encode_table((int)((block >> 18) & 0x3Fu));
-        out[out_idx++] = base64_encode_table((int)((block >> 12) & 0x3Fu));
-        out[out_idx++] = base64_encode_table((int)((block >> 6) & 0x3Fu));
-        out[out_idx++] = base64_encode_table((int)(block & 0x3Fu));
-    }
-
-    size_t remaining = size % 3u;
-    if (remaining == 1u) {
-        uint32_t block = ((uint32_t)data[size - 1u]) << 16;
-        out[out_idx++] = base64_encode_table((int)((block >> 18) & 0x3Fu));
-        out[out_idx++] = base64_encode_table((int)((block >> 12) & 0x3Fu));
-        out[out_idx++] = '=';
-        out[out_idx++] = '=';
-    } else if (remaining == 2u) {
-        uint32_t block = ((uint32_t)data[size - 2u] << 16) | ((uint32_t)data[size - 1u] << 8);
-        out[out_idx++] = base64_encode_table((int)((block >> 18) & 0x3Fu));
-        out[out_idx++] = base64_encode_table((int)((block >> 12) & 0x3Fu));
-        out[out_idx++] = base64_encode_table((int)((block >> 6) & 0x3Fu));
-        out[out_idx++] = '=';
-    }
-
-    out[out_idx] = '\0';
-    return 0;
+    fprintf(stderr, "  and pass that literal back to _TERM_SPRITE with -sprite.\n");
 }
 
 int main(int argc, char **argv) {
-    if (argc != 3) {
-        print_usage();
-        return EXIT_FAILURE;
-    }
-
     const char *file = NULL;
+
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "-file") == 0) {
             if (++i >= argc) {
@@ -101,71 +36,17 @@ int main(int argc, char **argv) {
         return EXIT_FAILURE;
     }
 
-    int width = 0;
-    int height = 0;
-    int channels = 0;
-    stbi_uc *pixels = stbi_load(file, &width, &height, &channels, 4);
-    if (!pixels) {
-        const char *reason = stbi_failure_reason();
-        if (reason && *reason) {
-            fprintf(stderr, "_TERM_SPRITE_LOAD: failed to load '%s': %s\n", file, reason);
-        } else {
-            fprintf(stderr, "_TERM_SPRITE_LOAD: failed to load '%s'\n", file);
-        }
+    char *literal = NULL;
+    if (termgfx_sprite_load_literal(file, &literal) != 0) {
         return EXIT_FAILURE;
     }
 
-    if (width <= 0 || height <= 0) {
-        stbi_image_free(pixels);
-        fprintf(stderr, "_TERM_SPRITE_LOAD: invalid image dimensions in '%s'\n", file);
-        return EXIT_FAILURE;
-    }
-
-    size_t width_sz = (size_t)width;
-    size_t height_sz = (size_t)height;
-    if (width_sz != 0 && height_sz > SIZE_MAX / width_sz) {
-        stbi_image_free(pixels);
-        fprintf(stderr, "_TERM_SPRITE_LOAD: image dimensions overflow.\n");
-        return EXIT_FAILURE;
-    }
-
-    size_t pixel_count = width_sz * height_sz;
-    if (pixel_count > SIZE_MAX / 4u) {
-        stbi_image_free(pixels);
-        fprintf(stderr, "_TERM_SPRITE_LOAD: image too large to encode.\n");
-        return EXIT_FAILURE;
-    }
-
-    size_t raw_size = pixel_count * 4u;
-    size_t encoded_size = base64_encoded_size(raw_size);
-    if (encoded_size == 0 || encoded_size > SIZE_MAX - 1u) {
-        stbi_image_free(pixels);
-        fprintf(stderr, "_TERM_SPRITE_LOAD: failed to compute encoded size.\n");
-        return EXIT_FAILURE;
-    }
-
-    char *encoded = malloc(encoded_size + 1u);
-    if (!encoded) {
-        stbi_image_free(pixels);
-        fprintf(stderr, "_TERM_SPRITE_LOAD: failed to allocate %zu bytes for encoding.\n", encoded_size + 1u);
-        return EXIT_FAILURE;
-    }
-
-    int encode_status = encode_base64(pixels, raw_size, encoded, encoded_size + 1u);
-    stbi_image_free(pixels);
-    if (encode_status != 0) {
-        free(encoded);
-        fprintf(stderr, "_TERM_SPRITE_LOAD: failed to encode image data.\n");
-        return EXIT_FAILURE;
-    }
-
-    if (printf("{%d,%d,\"%s\"}\n", width, height, encoded) < 0) {
+    if (printf("%s\n", literal) < 0) {
         perror("_TERM_SPRITE_LOAD: printf");
-        free(encoded);
+        free(literal);
         return EXIT_FAILURE;
     }
-
-    free(encoded);
+    free(literal);
 
     if (fflush(stdout) != 0) {
         perror("_TERM_SPRITE_LOAD: fflush");

--- a/commands/manual.md
+++ b/commands/manual.md
@@ -246,11 +246,28 @@ from the top-left corner; `LEFT`/`RIGHT` are button press counts since the last 
 **Description:** Shows (`enable`) or hides (`disable`) the mouse cursor in the
 terminal emulator.
 
+### `_TERM_PIXEL`
+**Usage:** `_TERM_PIXEL -x <pixels> -y <pixels> [-color <0-18> | -rgb <r> <g> <b>] [-layer <1-16>]`
+
+**Description:** Queues a single RGB pixel on the `apps/terminal` pixel surface.
+When called from TASK through `RUN _TERM_PIXEL`, `runtask` accelerates it in-process
+instead of spawning a command process. Use `_TERM_RENDER` to present queued pixels.
+
+### `_TERM_RECT`
+**Usage:** `_TERM_RECT -x <pixels> -y <pixels> -width <pixels> -height <pixels> [-color <0-18> | -rgb <r> <g> <b>] [-layer <1-16>]`
+
+**Description:** Queues a filled RGB rectangle on the `apps/terminal` pixel surface.
+TASK scripts get the same in-process acceleration as `_TERM_PIXEL`, making this the
+preferred primitive for fast QBASIC-style graphics loops. Use `_TERM_RENDER` once
+per frame to present queued rectangles.
+
 ### `_TERM_RENDER`
 **Usage:** `_TERM_RENDER [--render] [-layer <1-16>]`
 
 **Description:** Triggers rendering of the terminal pixel buffer. Use `-layer` to
-render only a single layer (1–16). Omitting `-layer` renders all layers.
+render only a single layer (1–16). Omitting `-layer` renders all layers. When
+called from TASK through `RUN _TERM_RENDER`, `runtask` accelerates it in-process
+instead of spawning a command process.
 
 ### `_TERM_TYPING_SOUND`
 **Usage:** `_TERM_TYPING_SOUND <enable|disable>`
@@ -298,13 +315,17 @@ _TERM_SPRITE -x <pixels> -y <pixels>
 **Description:** Draws a sprite onto the terminal’s pixel surface. Provide a PNG/BMP
 via `-file`, a literal from `_TERM_SPRITE_LOAD` via `-sprite`, or raw base64 RGBA data
 via `-data` along with `-width`/`-height`. Layer 1 is topmost; default layer is 1.
+TASK scripts get in-process acceleration for `RUN _TERM_SPRITE`, with `-sprite`
+literals being the preferred draw-loop path because the image file is loaded once.
 
 ### `_TERM_SPRITE_LOAD`
 **Usage:** `_TERM_SPRITE_LOAD -file <path>`
 
 **Description:** Loads a PNG/BMP sprite and prints a TASK array literal
 `{width,height,"<base64 RGBA data>"}`. Capture the output and reuse it with
-`_TERM_SPRITE -sprite ...` to avoid re-reading the file.
+`_TERM_SPRITE -sprite ...` to avoid re-reading the file. `RUN _TERM_SPRITE_LOAD ... TO $VAR`
+is accelerated in-process by `runtask`, so TASK setup code can preload sprites without
+spawning the external command wrapper.
 
 ### `_TERM_TEXT`
 **Usage:** `_TERM_TEXT -x <pixels> -y <pixels> -text <string> -color <1-18> [-layer <1-16>]`

--- a/lib/termgfx.c
+++ b/lib/termgfx.c
@@ -1,0 +1,457 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "termgfx.h"
+
+#include "retroprofile.h"
+#include "stb_image.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static long clamp_layer(long layer) {
+    if (layer < 1) {
+        return 1;
+    }
+    if (layer > 16) {
+        return 16;
+    }
+    return layer;
+}
+
+static size_t base64_encoded_size(size_t raw_size) {
+    size_t blocks = raw_size / 3u;
+    size_t encoded = blocks * 4u;
+
+    if (raw_size % 3u != 0u) {
+        encoded += 4u;
+    }
+    return encoded;
+}
+
+static char base64_encode_table(int idx) {
+    static const char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    if (idx < 0 || idx >= 64) {
+        return '=';
+    }
+    return table[idx];
+}
+
+static int encode_base64(const uint8_t *data, size_t size, char *out, size_t out_size) {
+    if (!data || !out) {
+        return -1;
+    }
+
+    size_t required = base64_encoded_size(size);
+    if (out_size < required + 1u) {
+        return -1;
+    }
+
+    size_t out_idx = 0u;
+    size_t i = 0u;
+    for (; i + 2u < size; i += 3u) {
+        uint32_t block = ((uint32_t)data[i] << 16) | ((uint32_t)data[i + 1u] << 8) | (uint32_t)data[i + 2u];
+        out[out_idx++] = base64_encode_table((int)((block >> 18) & 0x3fu));
+        out[out_idx++] = base64_encode_table((int)((block >> 12) & 0x3fu));
+        out[out_idx++] = base64_encode_table((int)((block >> 6) & 0x3fu));
+        out[out_idx++] = base64_encode_table((int)(block & 0x3fu));
+    }
+
+    if (i < size) {
+        uint32_t block = (uint32_t)data[i] << 16;
+        out[out_idx++] = base64_encode_table((int)((block >> 18) & 0x3fu));
+        if (i + 1u < size) {
+            block |= (uint32_t)data[i + 1u] << 8;
+            out[out_idx++] = base64_encode_table((int)((block >> 12) & 0x3fu));
+            out[out_idx++] = base64_encode_table((int)((block >> 6) & 0x3fu));
+            out[out_idx++] = '=';
+        } else {
+            out[out_idx++] = base64_encode_table((int)((block >> 12) & 0x3fu));
+            out[out_idx++] = '=';
+            out[out_idx++] = '=';
+        }
+    }
+
+    out[out_idx] = '\0';
+    return 0;
+}
+
+static int load_file_as_encoded_rgba(const char *path, int *width_out, int *height_out, char **encoded_out) {
+    if (!path || !width_out || !height_out || !encoded_out) {
+        fprintf(stderr, "termgfx: invalid sprite load argument.\n");
+        return -1;
+    }
+
+    *width_out = 0;
+    *height_out = 0;
+    *encoded_out = NULL;
+
+    int width = 0;
+    int height = 0;
+    int channels = 0;
+    stbi_uc *pixels = stbi_load(path, &width, &height, &channels, 4);
+    if (!pixels) {
+        const char *reason = stbi_failure_reason();
+        if (reason && *reason) {
+            fprintf(stderr, "termgfx: failed to load '%s': %s\n", path, reason);
+        } else {
+            fprintf(stderr, "termgfx: failed to load '%s'\n", path);
+        }
+        return -1;
+    }
+
+    if (width <= 0 || height <= 0) {
+        stbi_image_free(pixels);
+        fprintf(stderr, "termgfx: invalid image dimensions in '%s'\n", path);
+        return -1;
+    }
+
+    size_t width_sz = (size_t)width;
+    size_t height_sz = (size_t)height;
+    if (width_sz != 0u && height_sz > SIZE_MAX / width_sz) {
+        stbi_image_free(pixels);
+        fprintf(stderr, "termgfx: image dimensions overflow for '%s'.\n", path);
+        return -1;
+    }
+
+    size_t pixel_count = width_sz * height_sz;
+    if (pixel_count > SIZE_MAX / 4u) {
+        stbi_image_free(pixels);
+        fprintf(stderr, "termgfx: image too large to encode: '%s'.\n", path);
+        return -1;
+    }
+
+    size_t raw_size = pixel_count * 4u;
+    size_t encoded_size = base64_encoded_size(raw_size);
+    if (encoded_size == 0u || encoded_size > SIZE_MAX - 1u) {
+        stbi_image_free(pixels);
+        fprintf(stderr, "termgfx: failed to compute encoded size for '%s'.\n", path);
+        return -1;
+    }
+
+    char *encoded = (char *)malloc(encoded_size + 1u);
+    if (!encoded) {
+        stbi_image_free(pixels);
+        perror("termgfx: malloc");
+        return -1;
+    }
+
+    int encode_status = encode_base64(pixels, raw_size, encoded, encoded_size + 1u);
+    stbi_image_free(pixels);
+    if (encode_status != 0) {
+        free(encoded);
+        fprintf(stderr, "termgfx: failed to encode image data from '%s'.\n", path);
+        return -1;
+    }
+
+    *width_out = width;
+    *height_out = height;
+    *encoded_out = encoded;
+    return 0;
+}
+
+static int parse_sprite_literal(const char *literal, int *width_out, int *height_out, char **encoded_out) {
+    if (!literal || !width_out || !height_out || !encoded_out) {
+        return -1;
+    }
+
+    const char *p = literal;
+    while (isspace((unsigned char)*p)) {
+        p++;
+    }
+    if (*p != '{') {
+        fprintf(stderr, "termgfx: sprite literal must start with '{'.\n");
+        return -1;
+    }
+    p++;
+
+    errno = 0;
+    char *endptr = NULL;
+    long width = strtol(p, &endptr, 10);
+    if (errno != 0 || endptr == p || width <= 0 || width > INT_MAX) {
+        fprintf(stderr, "termgfx: invalid sprite width in literal.\n");
+        return -1;
+    }
+    p = endptr;
+    while (isspace((unsigned char)*p)) {
+        p++;
+    }
+    if (*p != ',') {
+        fprintf(stderr, "termgfx: sprite literal missing comma after width.\n");
+        return -1;
+    }
+    p++;
+
+    errno = 0;
+    long height = strtol(p, &endptr, 10);
+    if (errno != 0 || endptr == p || height <= 0 || height > INT_MAX) {
+        fprintf(stderr, "termgfx: invalid sprite height in literal.\n");
+        return -1;
+    }
+    p = endptr;
+    while (isspace((unsigned char)*p)) {
+        p++;
+    }
+    if (*p != ',') {
+        fprintf(stderr, "termgfx: sprite literal missing comma after height.\n");
+        return -1;
+    }
+    p++;
+    while (isspace((unsigned char)*p)) {
+        p++;
+    }
+
+    const char *data_start = p;
+    const char *data_end = NULL;
+    if (*p == '"') {
+        p++;
+        data_start = p;
+        while (*p && *p != '"') {
+            p++;
+        }
+        if (*p != '"') {
+            fprintf(stderr, "termgfx: sprite literal is missing the closing quote for data.\n");
+            return -1;
+        }
+        data_end = p;
+        p++;
+    } else {
+        while (*p && *p != '}') {
+            p++;
+        }
+        data_end = p;
+        while (data_end > data_start && isspace((unsigned char)data_end[-1])) {
+            data_end--;
+        }
+    }
+
+    if (data_end <= data_start) {
+        fprintf(stderr, "termgfx: sprite literal must contain base64 data.\n");
+        return -1;
+    }
+
+    size_t data_len = (size_t)(data_end - data_start);
+    char *encoded = (char *)malloc(data_len + 1u);
+    if (!encoded) {
+        perror("termgfx: malloc");
+        return -1;
+    }
+    memcpy(encoded, data_start, data_len);
+    encoded[data_len] = '\0';
+
+    while (isspace((unsigned char)*p)) {
+        p++;
+    }
+    if (*p != '}') {
+        free(encoded);
+        fprintf(stderr, "termgfx: sprite literal must end with '}'.\n");
+        return -1;
+    }
+    p++;
+    while (isspace((unsigned char)*p)) {
+        p++;
+    }
+    if (*p != '\0') {
+        free(encoded);
+        fprintf(stderr, "termgfx: unexpected characters after sprite literal.\n");
+        return -1;
+    }
+
+    *width_out = (int)width;
+    *height_out = (int)height;
+    *encoded_out = encoded;
+    return 0;
+}
+
+int termgfx_color_from_index(int index, uint8_t *r_out, uint8_t *g_out, uint8_t *b_out) {
+    if (!r_out || !g_out || !b_out) {
+        return -1;
+    }
+
+    if (index < 0) {
+        index = 0;
+    } else if (index > 18) {
+        index = 18;
+    }
+
+    const RetroProfile *profile = retroprofile_active();
+    if (!profile) {
+        return -1;
+    }
+
+    RetroColor color;
+    if (index >= 0 && index < 16) {
+        color = profile->colors[index];
+    } else if (index == 16) {
+        color = profile->defaults.foreground;
+    } else if (index == 17) {
+        color = profile->defaults.background;
+    } else {
+        color = profile->defaults.cursor;
+    }
+
+    *r_out = color.r;
+    *g_out = color.g;
+    *b_out = color.b;
+    return 0;
+}
+
+int termgfx_pixel(long x, long y, uint8_t r, uint8_t g, uint8_t b, long layer) {
+    if (x < 0 || y < 0) {
+        return -1;
+    }
+
+    if (printf("\x1b]777;pixel=draw;pixel_x=%ld;pixel_y=%ld;pixel_r=%u;pixel_g=%u;pixel_b=%u;pixel_layer=%ld\a",
+               x,
+               y,
+               (unsigned int)r,
+               (unsigned int)g,
+               (unsigned int)b,
+               clamp_layer(layer)) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int termgfx_rect(long x, long y, long width, long height, uint8_t r, uint8_t g, uint8_t b, long layer) {
+    if (x < 0 || y < 0 || width <= 0 || height <= 0) {
+        return -1;
+    }
+
+    if (printf("\x1b]777;pixel=rect;pixel_x=%ld;pixel_y=%ld;pixel_w=%ld;pixel_h=%ld;pixel_r=%u;pixel_g=%u;pixel_b=%u;pixel_layer=%ld\a",
+               x,
+               y,
+               width,
+               height,
+               (unsigned int)r,
+               (unsigned int)g,
+               (unsigned int)b,
+               clamp_layer(layer)) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int termgfx_clear(long x, long y, long width, long height, long layer) {
+    if (x < 0 || y < 0 || width <= 0 || height <= 0) {
+        return -1;
+    }
+
+    if (printf("\x1b]777;sprite=clear;sprite_x=%ld;sprite_y=%ld;sprite_w=%ld;sprite_h=%ld;sprite_layer=%ld\a",
+               x,
+               y,
+               width,
+               height,
+               clamp_layer(layer)) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int termgfx_render(long layer) {
+    if (layer <= 0) {
+        if (printf("\x1b]777;pixel=render\a") < 0) {
+            return -1;
+        }
+    } else {
+        if (printf("\x1b]777;pixel=render;pixel_layer=%ld\a", clamp_layer(layer)) < 0) {
+            return -1;
+        }
+    }
+
+    if (fflush(stdout) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int termgfx_sprite_data(long x, long y, long width, long height, const char *encoded_rgba, long layer) {
+    if (x < 0 || y < 0 || width <= 0 || height <= 0 || !encoded_rgba || *encoded_rgba == '\0') {
+        return -1;
+    }
+
+    if (printf("\x1b]777;sprite=draw;sprite_x=%ld;sprite_y=%ld;sprite_w=%ld;sprite_h=%ld;sprite_layer=%ld;sprite_data=%s\a",
+               x,
+               y,
+               width,
+               height,
+               clamp_layer(layer),
+               encoded_rgba) < 0) {
+        return -1;
+    }
+
+    return fflush(stdout) == 0 ? 0 : -1;
+}
+
+int termgfx_sprite_literal(long x, long y, const char *literal, long layer) {
+    int width = 0;
+    int height = 0;
+    char *encoded = NULL;
+
+    if (parse_sprite_literal(literal, &width, &height, &encoded) != 0) {
+        return -1;
+    }
+
+    int rc = termgfx_sprite_data(x, y, width, height, encoded, layer);
+    free(encoded);
+    return rc;
+}
+
+int termgfx_sprite_file(long x, long y, const char *path, long layer) {
+    int width = 0;
+    int height = 0;
+    char *encoded = NULL;
+
+    if (load_file_as_encoded_rgba(path, &width, &height, &encoded) != 0) {
+        return -1;
+    }
+
+    int rc = termgfx_sprite_data(x, y, width, height, encoded, layer);
+    free(encoded);
+    return rc;
+}
+
+int termgfx_sprite_load_literal(const char *path, char **literal_out) {
+    if (!literal_out) {
+        return -1;
+    }
+    *literal_out = NULL;
+
+    int width = 0;
+    int height = 0;
+    char *encoded = NULL;
+    if (load_file_as_encoded_rgba(path, &width, &height, &encoded) != 0) {
+        return -1;
+    }
+
+    int needed = snprintf(NULL, 0, "{%d,%d,\"%s\"}", width, height, encoded);
+    if (needed < 0) {
+        free(encoded);
+        return -1;
+    }
+
+    char *literal = (char *)malloc((size_t)needed + 1u);
+    if (!literal) {
+        free(encoded);
+        perror("termgfx: malloc");
+        return -1;
+    }
+
+    int written = snprintf(literal, (size_t)needed + 1u, "{%d,%d,\"%s\"}", width, height, encoded);
+    free(encoded);
+    if (written != needed) {
+        free(literal);
+        return -1;
+    }
+
+    *literal_out = literal;
+    return 0;
+}

--- a/lib/termgfx.h
+++ b/lib/termgfx.h
@@ -1,0 +1,16 @@
+#ifndef BUDOSTACK_TERMGFX_H
+#define BUDOSTACK_TERMGFX_H
+
+#include <stdint.h>
+
+int termgfx_color_from_index(int index, uint8_t *r_out, uint8_t *g_out, uint8_t *b_out);
+int termgfx_pixel(long x, long y, uint8_t r, uint8_t g, uint8_t b, long layer);
+int termgfx_rect(long x, long y, long width, long height, uint8_t r, uint8_t g, uint8_t b, long layer);
+int termgfx_clear(long x, long y, long width, long height, long layer);
+int termgfx_render(long layer);
+int termgfx_sprite_data(long x, long y, long width, long height, const char *encoded_rgba, long layer);
+int termgfx_sprite_literal(long x, long y, const char *literal, long layer);
+int termgfx_sprite_file(long x, long y, const char *path, long layer);
+int termgfx_sprite_load_literal(const char *path, char **literal_out);
+
+#endif

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -238,6 +238,8 @@
   _TERM_MARGIN         : Set terminal pixel render margin.
   _TERM_MOUSE          : Read mouse X/Y and left/right button counters.
   _TERM_MOUSE_SHOW     : Show or hide terminal mouse cursor.
+  _TERM_PIXEL          : Queue accelerated terminal framebuffer pixels.
+  _TERM_RECT           : Queue accelerated filled terminal framebuffer rectangles.
   _TERM_RENDER         : Trigger full render or render selected layer.
   _TERM_RESOLUTION     : Set pixel resolution (LOW/HIGH or width/height).
   _TERM_SCALE          : Set pixel scaling mode 1x or 2x.
@@ -245,9 +247,9 @@
   _TERM_SOUND_PLAY     : Play audio file on selected channel (1-32)
                          volume 0-100.
   _TERM_SOUND_STOP     : Stop audio playback on selected channel (1-32).
-  _TERM_SPRITE         : Draw sprite from file/literal/base64
+  _TERM_SPRITE         : Draw sprite from file/literal/base64; TASK RUN is accelerated.
                          on chosen layer.
-  _TERM_SPRITE_LOAD    : Load sprite and output reusable TASK sprite literal.
+  _TERM_SPRITE_LOAD    : Load reusable TASK sprite literal; TASK capture is accelerated.
   _TERM_TEXT           : Draw UTF-8 text in pixel space with color and layer.
   _TERM_TYPING_SOUND   : Enable or disable keyboard typing sound effects.
   _TEST                : Print terminal diagnostic grid and size info.

--- a/tasks/termgraphics.task
+++ b/tasks/termgraphics.task
@@ -4,13 +4,15 @@
 # _TERM_PIXEL, _TERM_RECT, _TERM_CLEAN, and _TERM_RENDER are accelerated inside
 # the TASK runtime instead of spawning one process for every draw operation.
 #
-# The final cleanup clears the terminal pixel layers used by this demo after a
-# short result pause. Without that, the terminal framebuffer can still show the
-# last graphics frame and make it look like the TASK script is still running.
+# The demo intentionally does not toggle _TERM_SHADER. Shader enable/disable is
+# persistent terminal state, so changing it here would surprise the caller after
+# the task exits. The final cleanup clears the terminal pixel layers used by this
+# demo after a short result pause. Without that, the terminal framebuffer can
+# still show the last graphics frame and make it look like the TASK script is
+# still running.
 
 RUN _TERM_RESOLUTION HIGH
 RUN _TERM_MARGIN 0
-RUN _TERM_SHADER disable
 RUN _TERM_RENDER
 
 SET $WIDTH = 800

--- a/tasks/termgraphics.task
+++ b/tasks/termgraphics.task
@@ -3,6 +3,10 @@
 # This demo intentionally uses _TERM* commands. When run through runtask,
 # _TERM_PIXEL, _TERM_RECT, _TERM_CLEAN, and _TERM_RENDER are accelerated inside
 # the TASK runtime instead of spawning one process for every draw operation.
+#
+# The final cleanup clears the terminal pixel layers used by this demo after a
+# short result pause. Without that, the terminal framebuffer can still show the
+# last graphics frame and make it look like the TASK script is still running.
 
 RUN _TERM_RESOLUTION HIGH
 RUN _TERM_MARGIN 0
@@ -12,6 +16,7 @@ RUN _TERM_RENDER
 SET $WIDTH = 800
 SET $HEIGHT = 450
 SET $LAYER = 6
+SET $TEXT_LAYER = 2
 SET $BACKGROUND_LAYER = 16
 SET $FRAMES = 90
 SET $FRAME = 0
@@ -119,7 +124,14 @@ END
 
 RUN _TIMER --stop
 RUN _TIMER --get TO $TIME
-RUN _TERM_TEXT -x 18 -y 18 -text "TASK _TERM graphics: accelerated rectangles + one render per frame" -color 16 -layer 2
-RUN _TERM_TEXT -x 18 -y 34 -text "Finished 90 frames. Runtime milliseconds:" -color 16 -layer 2
-RUN _TERM_TEXT -x 360 -y 34 -text $TIME -color 16 -layer 2
+RUN _TERM_TEXT -x 18 -y 18 -text "TASK _TERM graphics: accelerated rectangles + one render per frame" -color 16 -layer $TEXT_LAYER
+RUN _TERM_TEXT -x 18 -y 34 -text "Finished 90 frames. Runtime milliseconds:" -color 16 -layer $TEXT_LAYER
+RUN _TERM_TEXT -x 360 -y 34 -text $TIME -color 16 -layer $TEXT_LAYER
+RUN _TERM_TEXT -x 18 -y 50 -text "Cleaning demo framebuffer before returning to shell..." -color 16 -layer $TEXT_LAYER
 RUN _TERM_RENDER
+WAIT 2500
+RUN _TERM_CLEAN -x 0 -y 0 -width $WIDTH -height $HEIGHT -layer $TEXT_LAYER
+RUN _TERM_CLEAN -x 0 -y 0 -width $WIDTH -height $HEIGHT -layer $LAYER
+RUN _TERM_CLEAN -x 0 -y 0 -width $WIDTH -height $HEIGHT -layer $BACKGROUND_LAYER
+RUN _TERM_RENDER
+PRINT "termgraphics.task finished; terminal graphics layers were cleaned."

--- a/tasks/termgraphics.task
+++ b/tasks/termgraphics.task
@@ -131,9 +131,10 @@ RUN _TERM_TEXT -x 18 -y 34 -text "Finished 90 frames. Runtime milliseconds:" -co
 RUN _TERM_TEXT -x 360 -y 34 -text $TIME -color 16 -layer $TEXT_LAYER
 RUN _TERM_TEXT -x 18 -y 50 -text "Cleaning demo framebuffer before returning to shell..." -color 16 -layer $TEXT_LAYER
 RUN _TERM_RENDER
-WAIT 2500
+WAIT 5000
 RUN _TERM_CLEAN -x 0 -y 0 -width $WIDTH -height $HEIGHT -layer $TEXT_LAYER
 RUN _TERM_CLEAN -x 0 -y 0 -width $WIDTH -height $HEIGHT -layer $LAYER
 RUN _TERM_CLEAN -x 0 -y 0 -width $WIDTH -height $HEIGHT -layer $BACKGROUND_LAYER
 RUN _TERM_RENDER
-PRINT "termgraphics.task finished; terminal graphics layers were cleaned."
+RUN _TERM_RESOLUTION LOW
+RUN _TERM_MARGIN 8

--- a/tasks/termgraphics.task
+++ b/tasks/termgraphics.task
@@ -1,0 +1,125 @@
+# termgraphics.task - accelerated TASK pixel graphics for apps/terminal
+#
+# This demo intentionally uses _TERM* commands. When run through runtask,
+# _TERM_PIXEL, _TERM_RECT, _TERM_CLEAN, and _TERM_RENDER are accelerated inside
+# the TASK runtime instead of spawning one process for every draw operation.
+
+RUN _TERM_RESOLUTION HIGH
+RUN _TERM_MARGIN 0
+RUN _TERM_SHADER disable
+RUN _TERM_RENDER
+
+SET $WIDTH = 800
+SET $HEIGHT = 450
+SET $LAYER = 6
+SET $BACKGROUND_LAYER = 16
+SET $FRAMES = 90
+SET $FRAME = 0
+
+RUN _TERM_RECT -x 0 -y 0 -width $WIDTH -height $HEIGHT -rgb 4 6 16 -layer $BACKGROUND_LAYER
+RUN _TERM_RENDER -layer $BACKGROUND_LAYER
+
+RUN _TIMER --stop
+RUN _TIMER --reset
+RUN _TIMER --start
+
+WHILE ($FRAME < $FRAMES):
+  RUN _TERM_CLEAN -x 0 -y 0 -width $WIDTH -height $HEIGHT -layer $LAYER
+
+  SET $X = $FRAME * 11
+  SET $Y = $FRAME * 7
+  SET $R = $FRAME * 3
+  SET $G = 80 + $FRAME * 5
+  SET $B = 255 - $FRAME * 2
+  WHILE ($X >= $WIDTH):
+    SET $X = $X - $WIDTH
+  END
+  WHILE ($Y >= $HEIGHT):
+    SET $Y = $Y - $HEIGHT
+  END
+  WHILE ($R >= 256):
+    SET $R = $R - 256
+  END
+  WHILE ($G >= 256):
+    SET $G = $G - 176
+  END
+  WHILE ($B < 75):
+    SET $B = $B + 180
+  END
+
+  SET $I = 0
+  WHILE ($I < 180):
+    RUN _TERM_RECT -x $X -y $Y -width 4 -height 4 -rgb $R $G $B -layer $LAYER
+    SET $X = $X + 37
+    SET $Y = $Y + 19
+    SET $R = $R + 5
+    SET $G = $G + 9
+    SET $B = $B - 13
+    IF ($X >= $WIDTH):
+      SET $X = $X - $WIDTH
+    END
+    IF ($Y >= $HEIGHT):
+      SET $Y = $Y - $HEIGHT
+    END
+    IF ($R >= 256):
+      SET $R = $R - 256
+    END
+    IF ($G >= 256):
+      SET $G = $G - 176
+    END
+    IF ($B < 75):
+      SET $B = $B + 180
+    END
+    SET $I = $I + 1
+  END
+
+  SET $BX = $FRAME * 6
+  WHILE ($BX >= $WIDTH):
+    SET $BX = $BX - $WIDTH
+  END
+  SET $BY = 40 + $FRAME * 4
+  WHILE ($BY >= 370):
+    SET $BY = $BY - 330
+  END
+  SET $BH = 20 + $FRAME
+  WHILE ($BH >= 100):
+    SET $BH = $BH - 80
+  END
+  SET $BR = 0
+  SET $BG = 255
+  SET $BAR = 0
+  WHILE ($BAR < 32):
+    RUN _TERM_RECT -x $BX -y $BY -width 10 -height $BH -rgb $BR $BG 220 -layer $LAYER
+    SET $BX = $BX + 25
+    SET $BY = $BY + 11
+    SET $BH = $BH + 3
+    SET $BR = $BR + 8
+    SET $BG = $BG - 6
+    IF ($BX >= $WIDTH):
+      SET $BX = $BX - $WIDTH
+    END
+    IF ($BY >= 370):
+      SET $BY = $BY - 330
+    END
+    IF ($BH >= 100):
+      SET $BH = $BH - 80
+    END
+    IF ($BR >= 256):
+      SET $BR = $BR - 256
+    END
+    IF ($BG < 55):
+      SET $BG = $BG + 200
+    END
+    SET $BAR = $BAR + 1
+  END
+
+  RUN _TERM_RENDER -layer $LAYER
+  SET $FRAME = $FRAME + 1
+END
+
+RUN _TIMER --stop
+RUN _TIMER --get TO $TIME
+RUN _TERM_TEXT -x 18 -y 18 -text "TASK _TERM graphics: accelerated rectangles + one render per frame" -color 16 -layer 2
+RUN _TERM_TEXT -x 18 -y 34 -text "Finished 90 frames. Runtime milliseconds:" -color 16 -layer 2
+RUN _TERM_TEXT -x 360 -y 34 -text $TIME -color 16 -layer 2
+RUN _TERM_RENDER


### PR DESCRIPTION
### Motivation
- Reduce per-draw fork/exec and escape-sequence overhead so TASK scripts can perform QBASIC/C64-style fast pixel graphics.
- Provide a single shared backend for pixel/rect/sprite operations used by both command wrappers and the in-process TASK fast path.
- Keep existing TASK scripts and capture semantics working while enabling high-volume draws and a demo that shows the performance.

### Description
- Add a reusable `lib/termgfx` API (`lib/termgfx.h` / `lib/termgfx.c`) that handles color resolution, base64 RGBA encoding/decoding, OSC 777 sprite emission, and helpers: `termgfx_pixel`, `termgfx_rect`, `termgfx_clear`, `termgfx_render`, `termgfx_sprite_*` and `termgfx_sprite_load_literal`.
- Accelerate TASK `RUN` by extending the `runtask` dispatcher to handle `_TERM_PIXEL`, `_TERM_RECT`, `_TERM_CLEAN`, `_TERM_RENDER`, `_TERM_SPRITE`, and `_TERM_SPRITE_LOAD` in-process using `termgfx` (no fork/exec for these hot commands) and preserve `TO $VAR` capture semantics for `_TERM_SPRITE_LOAD`.
- Refactor `_TERM_SPRITE` and `_TERM_SPRITE_LOAD` command wrappers to call `termgfx` helpers instead of duplicating image/base64 logic, and add standalone `_TERM_PIXEL` and `_TERM_RECT` command binaries that use `termgfx`.
- Extend `apps/terminal.c` to accept `pixel=rect` OSC action and implemented `terminal_custom_pixels_draw_rect(...)` to apply queued rectangles into the terminal custom-pixel surface, and add `tasks/termgraphics.task` as an accelerated demo.

### Testing
- Ran `make clean all` from repo root; build completed successfully but the environment lacks optional SDL2 development files so the SDL terminal target is skipped (logged warning) — overall compile succeeded with new files linked into the standard build.
- Smoke-tested accelerated TASK flows: `./apps/runtask tasks/.term_sprite_builtin_smoke.task -d` exercised `RUN _TERM_SPRITE_LOAD ... TO $VAR`, `RUN _TERM_SPRITE`, and `RUN _TERM_RENDER` and printed debug lines showing they were accelerated (succeeded).
- Executed the demo `./apps/runtask tasks/termgraphics.task` and verified output/bytes produced (no stderr); also validated standalone command output such as `_TERM_SPRITE -data` produced the expected OSC sequence — all automated smoke checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a195914e32c832793623020fe763dbc)