### PR TITLE
Add interactive terminal file explorer app and make list utility includable

### DIFF
--- a/apps/explorer.c
+++ b/apps/explorer.c
@@ -31,9 +31,7 @@ enum ExplorerKey {
     KEY_END,
     KEY_PAGE_UP,
     KEY_PAGE_DOWN,
-    KEY_DELETE,
-    KEY_SHIFT_UP,
-    KEY_SHIFT_DOWN
+    KEY_DELETE
 };
 
 enum ExplorerClipboardMode {
@@ -151,22 +149,6 @@ static int explorer_read_key(void)
 
         if (seq[0] == '[' && len >= 2) {
             char final = seq[len - 1];
-            int shifted = 0;
-            size_t i;
-
-            for (i = 1; i + 1 < len; i++) {
-                if (seq[i] == ';' && seq[i + 1] == '2') {
-                    shifted = 1;
-                    break;
-                }
-            }
-
-            if (shifted && final == 'A') {
-                return KEY_SHIFT_UP;
-            }
-            if (shifted && final == 'B') {
-                return KEY_SHIFT_DOWN;
-            }
 
             switch (final) {
                 case 'A':
@@ -382,7 +364,7 @@ static int explorer_load_directory(const char *dir_path)
     qsort(E.entries, E.entry_count, sizeof(*E.entries), explorer_entry_compare);
     E.selected = 0;
     E.scroll = 0;
-    explorer_set_status("%zu entries. c copies, m moves, p pastes. Space marks; Shift+Up/Down marks ranges; Ctrl+A marks all.", E.entry_count);
+    explorer_set_status("%zu entries", E.entry_count);
     return 0;
 }
 
@@ -437,15 +419,30 @@ static void explorer_toggle_mark_selected(void)
 static void explorer_mark_all(void)
 {
     size_t i;
+    size_t actionable = 0;
     size_t marked = 0;
 
     for (i = 0; i < E.entry_count; i++) {
         if (explorer_entry_is_actionable(&E.entries[i])) {
-            E.entries[i].marked = 1;
-            marked++;
+            actionable++;
+            if (E.entries[i].marked) {
+                marked++;
+            }
         }
     }
-    explorer_set_status("Marked %zu entries", marked);
+
+    if (actionable > 0 && marked == actionable) {
+        explorer_clear_marks();
+        explorer_set_status("Cleared all marks");
+        return;
+    }
+
+    for (i = 0; i < E.entry_count; i++) {
+        if (explorer_entry_is_actionable(&E.entries[i])) {
+            E.entries[i].marked = 1;
+        }
+    }
+    explorer_set_status("Marked %zu entries", actionable);
 }
 
 static void explorer_free_clipboard(void)
@@ -738,7 +735,7 @@ static void explorer_set_clipboard(int mode)
     E.clipboard_paths = paths;
     E.clipboard_count = count;
     E.clipboard_mode = mode;
-    explorer_set_status("%s %zu item%s. Navigate to a target folder and press p to paste.",
+    explorer_set_status("%s %zu item%s",
         mode == CLIPBOARD_COPY ? "Copied" : "Prepared move for",
         count,
         count == 1 ? "" : "s");
@@ -752,7 +749,7 @@ static void explorer_paste_clipboard(void)
     char first_error[EXPLORER_STATUS_SIZE] = "";
 
     if (E.clipboard_count == 0 || E.clipboard_mode == CLIPBOARD_EMPTY) {
-        explorer_set_status("Clipboard is empty. Use c to copy or m to move first.");
+        explorer_set_status("Clipboard is empty");
         return;
     }
 
@@ -880,6 +877,75 @@ static void explorer_draw_bar_text(const char *left, const char *right, int row)
     printf("\x1b[0m");
 }
 
+
+static void explorer_copy_segment(char *line, size_t line_size, int start, int width, const char *text)
+{
+    int i;
+
+    if (start < 0 || width <= 0 || (size_t)start >= line_size) {
+        return;
+    }
+    for (i = 0; i < width && text[i] != '\0' && (size_t)(start + i) + 1 < line_size; i++) {
+        line[start + i] = text[i];
+    }
+}
+
+static void explorer_draw_top_bar(const char *left, const char *right)
+{
+    char line[1024];
+    char center[32];
+    time_t now;
+    struct tm *tm_info;
+    int width;
+    int center_len;
+    int center_start;
+    int right_len;
+    int right_start;
+    int left_width;
+
+    width = E.cols;
+    if (width <= 0) {
+        return;
+    }
+    if (width >= (int)sizeof(line)) {
+        width = (int)sizeof(line) - 1;
+    }
+    memset(line, ' ', (size_t)width);
+    line[width] = '\0';
+
+    now = time(NULL);
+    tm_info = localtime(&now);
+    if (tm_info != NULL) {
+        strftime(center, sizeof(center), "%Y-%m-%d %H:%M", tm_info);
+    } else {
+        snprintf(center, sizeof(center), "date unavailable");
+    }
+
+    center_len = (int)strlen(center);
+    center_start = (width - center_len) / 2;
+    if (center_start < 0) {
+        center_start = 0;
+    }
+
+    right_len = (int)strlen(right);
+    right_start = width - right_len;
+    if (right_start < center_start + center_len + 1) {
+        right_start = width;
+    }
+
+    left_width = center_start - 1;
+    if (left_width < 0) {
+        left_width = 0;
+    }
+    explorer_copy_segment(line, sizeof(line), 0, left_width, left);
+    explorer_copy_segment(line, sizeof(line), center_start, center_len, center);
+    if (right_start < width) {
+        explorer_copy_segment(line, sizeof(line), right_start, right_len, right);
+    }
+
+    printf("\x1b[1;1H\x1b[7m%.*s\x1b[0m", width, line);
+}
+
 static void explorer_draw_entry(const ExplorerEntry *entry, int row, int selected, int name_width)
 {
     char display_name[PATH_MAX + 4];
@@ -937,15 +1003,15 @@ static void explorer_draw_screen(void)
     explorer_scroll_to_cursor();
     visible_rows = (size_t)(E.rows - 5);
     marked = explorer_marked_count();
-    name_width = E.cols - 48;
-    if (name_width < 16) {
-        name_width = 16;
+    name_width = E.cols - 45;
+    if (name_width < 8) {
+        name_width = 8;
     }
 
     printf("\x1b[?25l\x1b[2J\x1b[H");
     snprintf(title, sizeof(title), " BUDOSTACK Explorer  %s ", E.cwd);
     snprintf(right, sizeof(right), " %zu/%zu  marked:%zu  clip:%zu ", E.entry_count == 0 ? 0 : E.selected + 1, E.entry_count, marked, E.clipboard_count);
-    explorer_draw_bar_text(title, right, 1);
+    explorer_draw_top_bar(title, right);
 
     printf("\x1b[2;1H+");
     explorer_draw_repeated('-', E.cols - 2);
@@ -967,7 +1033,7 @@ static void explorer_draw_screen(void)
     explorer_draw_repeated('-', E.cols - 2);
     printf("+");
     explorer_draw_bar_text(E.status, E.show_hidden ? " hidden:on " : " hidden:off ", E.rows - 2);
-    explorer_draw_bar_text(" ↑↓ Move  Shift↑↓ Mark  Space Mark  ^A All  c Copy  m Move  p Paste ", " Enter Open  q Quit ", E.rows);
+    explorer_draw_bar_text(" ↑↓Move EnterOpen SpaceMark ^TSelect ^AAll/None cCopy mMove pPaste ", " qQuit ", E.rows);
     fflush(stdout);
 }
 
@@ -1018,7 +1084,7 @@ static void explorer_open_selected(void)
     if (entry->is_dir) {
         explorer_load_directory(entry->path);
     } else {
-        explorer_set_status("File: %s. Press e to edit, d to delete, r to rename.", entry->name);
+        explorer_set_status("File: %s", entry->name);
     }
 }
 
@@ -1178,12 +1244,6 @@ static void explorer_process_key(int key)
         case 'j':
             explorer_move_cursor(1, E.selection_mode);
             break;
-        case KEY_SHIFT_UP:
-            explorer_move_cursor(-1, 1);
-            break;
-        case KEY_SHIFT_DOWN:
-            explorer_move_cursor(1, 1);
-            break;
         case KEY_PAGE_UP:
             if (E.selected > visible_rows) {
                 E.selected -= visible_rows;
@@ -1224,7 +1284,7 @@ static void explorer_process_key(int key)
             break;
         case CTRL_KEY('t'):
             E.selection_mode = !E.selection_mode;
-            explorer_set_status("Selection mode %s. Use arrows to mark ranges, Space/Enter to toggle entries.", E.selection_mode ? "on" : "off");
+            explorer_set_status("Selection mode %s", E.selection_mode ? "on" : "off");
             break;
         case ' ':
             explorer_toggle_mark_selected();
@@ -1259,7 +1319,7 @@ static void explorer_process_key(int key)
             explorer_edit_selected();
             break;
         default:
-            explorer_set_status("Shortcuts: Space mark, Ctrl+A all, Ctrl+T selection mode, c copy, m move, p paste, e edit, q quit.");
+            explorer_set_status("Unknown key");
             break;
     }
 }

--- a/apps/explorer.c
+++ b/apps/explorer.c
@@ -5,6 +5,7 @@
 #include "../lib/terminal_layout.h"
 
 #include <ctype.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <signal.h>
 #include <stdarg.h>
@@ -30,7 +31,15 @@ enum ExplorerKey {
     KEY_END,
     KEY_PAGE_UP,
     KEY_PAGE_DOWN,
-    KEY_DELETE
+    KEY_DELETE,
+    KEY_SHIFT_UP,
+    KEY_SHIFT_DOWN
+};
+
+enum ExplorerClipboardMode {
+    CLIPBOARD_EMPTY = 0,
+    CLIPBOARD_COPY,
+    CLIPBOARD_MOVE
 };
 
 typedef struct {
@@ -40,6 +49,7 @@ typedef struct {
     off_t size;
     time_t mtime;
     int is_dir;
+    int marked;
 } ExplorerEntry;
 
 typedef struct {
@@ -55,6 +65,10 @@ typedef struct {
     int show_hidden;
     int running;
     char edit_path[PATH_MAX];
+    int selection_mode;
+    char **clipboard_paths;
+    size_t clipboard_count;
+    int clipboard_mode;
 } ExplorerState;
 
 static ExplorerState E;
@@ -116,53 +130,78 @@ static int explorer_read_key(void)
     }
 
     if (c == '\x1b') {
-        char seq[3];
+        char seq[8];
+        size_t len = 0;
 
-        if (read(STDIN_FILENO, &seq[0], 1) != 1) {
+        if (read(STDIN_FILENO, &seq[len], 1) != 1) {
             return '\x1b';
         }
-        if (read(STDIN_FILENO, &seq[1], 1) != 1) {
+        len++;
+        if (seq[0] != '[' && seq[0] != 'O') {
             return '\x1b';
         }
 
-        if (seq[0] == '[') {
-            if (seq[1] >= '0' && seq[1] <= '9') {
-                if (read(STDIN_FILENO, &seq[2], 1) != 1) {
-                    return '\x1b';
-                }
-                if (seq[2] == '~') {
-                    switch (seq[1]) {
-                        case '1':
-                        case '7':
-                            return KEY_HOME;
-                        case '3':
-                            return KEY_DELETE;
-                        case '4':
-                        case '8':
-                            return KEY_END;
-                        case '5':
-                            return KEY_PAGE_UP;
-                        case '6':
-                            return KEY_PAGE_DOWN;
-                    }
-                }
-            } else {
-                switch (seq[1]) {
-                    case 'A':
-                        return KEY_ARROW_UP;
-                    case 'B':
-                        return KEY_ARROW_DOWN;
-                    case 'C':
-                        return KEY_ARROW_RIGHT;
-                    case 'D':
-                        return KEY_ARROW_LEFT;
-                    case 'H':
-                        return KEY_HOME;
-                    case 'F':
-                        return KEY_END;
+        while (len < sizeof(seq) && read(STDIN_FILENO, &seq[len], 1) == 1) {
+            if ((seq[len] >= 'A' && seq[len] <= 'Z') || seq[len] == '~') {
+                len++;
+                break;
+            }
+            len++;
+        }
+
+        if (seq[0] == '[' && len >= 2) {
+            char final = seq[len - 1];
+            int shifted = 0;
+            size_t i;
+
+            for (i = 1; i + 1 < len; i++) {
+                if (seq[i] == ';' && seq[i + 1] == '2') {
+                    shifted = 1;
+                    break;
                 }
             }
+
+            if (shifted && final == 'A') {
+                return KEY_SHIFT_UP;
+            }
+            if (shifted && final == 'B') {
+                return KEY_SHIFT_DOWN;
+            }
+
+            switch (final) {
+                case 'A':
+                    return KEY_ARROW_UP;
+                case 'B':
+                    return KEY_ARROW_DOWN;
+                case 'C':
+                    return KEY_ARROW_RIGHT;
+                case 'D':
+                    return KEY_ARROW_LEFT;
+                case 'H':
+                    return KEY_HOME;
+                case 'F':
+                    return KEY_END;
+                case '~':
+                    if (len >= 3) {
+                        switch (seq[1]) {
+                            case '1':
+                            case '7':
+                                return KEY_HOME;
+                            case '3':
+                                return KEY_DELETE;
+                            case '4':
+                            case '8':
+                                return KEY_END;
+                            case '5':
+                                return KEY_PAGE_UP;
+                            case '6':
+                                return KEY_PAGE_DOWN;
+                        }
+                    }
+                    break;
+            }
         }
+
         return '\x1b';
     }
 
@@ -343,7 +382,7 @@ static int explorer_load_directory(const char *dir_path)
     qsort(E.entries, E.entry_count, sizeof(*E.entries), explorer_entry_compare);
     E.selected = 0;
     E.scroll = 0;
-    explorer_set_status("%zu entries. Enter opens, e edits via ./apps/edit, d deletes, r renames, n creates a folder.", E.entry_count);
+    explorer_set_status("%zu entries. c copies, m moves, p pastes. Space marks; Shift+Up/Down marks ranges; Ctrl+A marks all.", E.entry_count);
     return 0;
 }
 
@@ -353,6 +392,430 @@ static ExplorerEntry *explorer_selected_entry(void)
         return NULL;
     }
     return &E.entries[E.selected];
+}
+
+
+static int explorer_entry_is_actionable(const ExplorerEntry *entry)
+{
+    return entry != NULL && strcmp(entry->name, "..") != 0;
+}
+
+static size_t explorer_marked_count(void)
+{
+    size_t count = 0;
+    size_t i;
+
+    for (i = 0; i < E.entry_count; i++) {
+        if (E.entries[i].marked && explorer_entry_is_actionable(&E.entries[i])) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static void explorer_clear_marks(void)
+{
+    size_t i;
+
+    for (i = 0; i < E.entry_count; i++) {
+        E.entries[i].marked = 0;
+    }
+}
+
+static void explorer_toggle_mark_selected(void)
+{
+    ExplorerEntry *entry = explorer_selected_entry();
+
+    if (!explorer_entry_is_actionable(entry)) {
+        explorer_set_status("Cannot mark parent directory entry");
+        return;
+    }
+    entry->marked = !entry->marked;
+    explorer_set_status("%s %s", entry->marked ? "Marked" : "Unmarked", entry->name);
+}
+
+static void explorer_mark_all(void)
+{
+    size_t i;
+    size_t marked = 0;
+
+    for (i = 0; i < E.entry_count; i++) {
+        if (explorer_entry_is_actionable(&E.entries[i])) {
+            E.entries[i].marked = 1;
+            marked++;
+        }
+    }
+    explorer_set_status("Marked %zu entries", marked);
+}
+
+static void explorer_free_clipboard(void)
+{
+    size_t i;
+
+    for (i = 0; i < E.clipboard_count; i++) {
+        free(E.clipboard_paths[i]);
+    }
+    free(E.clipboard_paths);
+    E.clipboard_paths = NULL;
+    E.clipboard_count = 0;
+    E.clipboard_mode = CLIPBOARD_EMPTY;
+}
+
+static const char *explorer_basename(const char *path)
+{
+    const char *slash = strrchr(path, '/');
+
+    if (slash == NULL) {
+        return path;
+    }
+    return slash + 1;
+}
+
+static int explorer_join_path(char *output, size_t output_size, const char *dir_path, const char *name)
+{
+    int written;
+
+    written = snprintf(output, output_size, "%s/%s", dir_path, name);
+    if (written < 0 || (size_t)written >= output_size) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    return 0;
+}
+
+static int explorer_copy_file(const char *src, const char *dst, mode_t mode)
+{
+    int in_fd;
+    int out_fd;
+    char buffer[16384];
+    ssize_t nread;
+
+    in_fd = open(src, O_RDONLY);
+    if (in_fd == -1) {
+        return -1;
+    }
+    out_fd = open(dst, O_WRONLY | O_CREAT | O_EXCL, mode & 0777);
+    if (out_fd == -1) {
+        int saved_errno = errno;
+        close(in_fd);
+        errno = saved_errno;
+        return -1;
+    }
+
+    while ((nread = read(in_fd, buffer, sizeof(buffer))) > 0) {
+        ssize_t offset = 0;
+
+        while (offset < nread) {
+            ssize_t nwritten = write(out_fd, buffer + offset, (size_t)(nread - offset));
+            if (nwritten == -1) {
+                int saved_errno = errno;
+                close(in_fd);
+                close(out_fd);
+                unlink(dst);
+                errno = saved_errno;
+                return -1;
+            }
+            offset += nwritten;
+        }
+    }
+
+    if (nread == -1) {
+        int saved_errno = errno;
+        close(in_fd);
+        close(out_fd);
+        unlink(dst);
+        errno = saved_errno;
+        return -1;
+    }
+    if (close(in_fd) == -1) {
+        int saved_errno = errno;
+        close(out_fd);
+        errno = saved_errno;
+        return -1;
+    }
+    if (close(out_fd) == -1) {
+        return -1;
+    }
+    return 0;
+}
+
+static int explorer_copy_symlink(const char *src, const char *dst)
+{
+    char target[PATH_MAX];
+    ssize_t len;
+
+    len = readlink(src, target, sizeof(target) - 1);
+    if (len == -1) {
+        return -1;
+    }
+    target[len] = '\0';
+    return symlink(target, dst);
+}
+
+static int explorer_copy_recursive(const char *src, const char *dst)
+{
+    struct stat st;
+    struct stat dst_st;
+    DIR *dir;
+    struct dirent *entry;
+
+    if (lstat(src, &st) == -1) {
+        return -1;
+    }
+    if (lstat(dst, &dst_st) == 0) {
+        errno = EEXIST;
+        return -1;
+    }
+
+    if (S_ISLNK(st.st_mode)) {
+        return explorer_copy_symlink(src, dst);
+    }
+    if (!S_ISDIR(st.st_mode)) {
+        return explorer_copy_file(src, dst, st.st_mode);
+    }
+
+    if (mkdir(dst, st.st_mode & 0777) == -1) {
+        return -1;
+    }
+    dir = opendir(src);
+    if (dir == NULL) {
+        int saved_errno = errno;
+        rmdir(dst);
+        errno = saved_errno;
+        return -1;
+    }
+
+    while ((entry = readdir(dir)) != NULL) {
+        char child_src[PATH_MAX];
+        char child_dst[PATH_MAX];
+
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        if (explorer_join_path(child_src, sizeof(child_src), src, entry->d_name) == -1 ||
+            explorer_join_path(child_dst, sizeof(child_dst), dst, entry->d_name) == -1 ||
+            explorer_copy_recursive(child_src, child_dst) == -1) {
+            int saved_errno = errno;
+            closedir(dir);
+            errno = saved_errno;
+            return -1;
+        }
+    }
+
+    if (closedir(dir) == -1) {
+        return -1;
+    }
+    return 0;
+}
+
+static int explorer_delete_tree(const char *path)
+{
+    struct stat st;
+    DIR *dir;
+    struct dirent *entry;
+
+    if (lstat(path, &st) == -1) {
+        return -1;
+    }
+    if (!S_ISDIR(st.st_mode) || S_ISLNK(st.st_mode)) {
+        return unlink(path);
+    }
+
+    dir = opendir(path);
+    if (dir == NULL) {
+        return -1;
+    }
+    while ((entry = readdir(dir)) != NULL) {
+        char child[PATH_MAX];
+
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        if (explorer_join_path(child, sizeof(child), path, entry->d_name) == -1 || explorer_delete_tree(child) == -1) {
+            int saved_errno = errno;
+            closedir(dir);
+            errno = saved_errno;
+            return -1;
+        }
+    }
+    if (closedir(dir) == -1) {
+        return -1;
+    }
+    return rmdir(path);
+}
+
+static int explorer_path_contains_destination(const char *src, const char *dst)
+{
+    size_t src_len = strlen(src);
+
+    return strncmp(src, dst, src_len) == 0 && (dst[src_len] == '/' || dst[src_len] == '\0');
+}
+
+static int explorer_move_path(const char *src, const char *dst)
+{
+    if (explorer_path_contains_destination(src, dst)) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (rename(src, dst) == 0) {
+        return 0;
+    }
+    if (errno != EXDEV) {
+        return -1;
+    }
+    if (explorer_copy_recursive(src, dst) == -1) {
+        return -1;
+    }
+    return explorer_delete_tree(src);
+}
+
+static int explorer_collect_marked_or_current(char ***paths, size_t *count)
+{
+    size_t marked = explorer_marked_count();
+    size_t capacity = marked > 0 ? marked : 1;
+    size_t used = 0;
+    char **items;
+    size_t i;
+
+    *paths = NULL;
+    *count = 0;
+    items = calloc(capacity, sizeof(*items));
+    if (items == NULL) {
+        return -1;
+    }
+
+    if (marked > 0) {
+        for (i = 0; i < E.entry_count; i++) {
+            if (E.entries[i].marked && explorer_entry_is_actionable(&E.entries[i])) {
+                items[used] = strdup(E.entries[i].path);
+                if (items[used] == NULL) {
+                    size_t j;
+                    for (j = 0; j < used; j++) {
+                        free(items[j]);
+                    }
+                    free(items);
+                    return -1;
+                }
+                used++;
+            }
+        }
+    } else {
+        ExplorerEntry *entry = explorer_selected_entry();
+
+        if (!explorer_entry_is_actionable(entry)) {
+            free(items);
+            return 0;
+        }
+        items[0] = strdup(entry->path);
+        if (items[0] == NULL) {
+            free(items);
+            return -1;
+        }
+        used = 1;
+    }
+
+    *paths = items;
+    *count = used;
+    return 0;
+}
+
+static void explorer_set_clipboard(int mode)
+{
+    char **paths;
+    size_t count;
+
+    if (explorer_collect_marked_or_current(&paths, &count) == -1) {
+        explorer_set_status("Out of memory while preparing clipboard");
+        return;
+    }
+    if (count == 0) {
+        free(paths);
+        explorer_set_status("Select a file or folder before copy/move");
+        return;
+    }
+
+    explorer_free_clipboard();
+    E.clipboard_paths = paths;
+    E.clipboard_count = count;
+    E.clipboard_mode = mode;
+    explorer_set_status("%s %zu item%s. Navigate to a target folder and press p to paste.",
+        mode == CLIPBOARD_COPY ? "Copied" : "Prepared move for",
+        count,
+        count == 1 ? "" : "s");
+}
+
+static void explorer_paste_clipboard(void)
+{
+    size_t i;
+    size_t pasted = 0;
+    size_t failed = 0;
+    char first_error[EXPLORER_STATUS_SIZE] = "";
+
+    if (E.clipboard_count == 0 || E.clipboard_mode == CLIPBOARD_EMPTY) {
+        explorer_set_status("Clipboard is empty. Use c to copy or m to move first.");
+        return;
+    }
+
+    for (i = 0; i < E.clipboard_count; i++) {
+        char destination[PATH_MAX];
+        const char *name = explorer_basename(E.clipboard_paths[i]);
+
+        if (explorer_join_path(destination, sizeof(destination), E.cwd, name) == -1) {
+            failed++;
+            if (first_error[0] == '\0') {
+                snprintf(first_error, sizeof(first_error), "%s: %s", name, strerror(errno));
+            }
+            continue;
+        }
+
+        if ((E.clipboard_mode == CLIPBOARD_COPY && explorer_copy_recursive(E.clipboard_paths[i], destination) == 0) ||
+            (E.clipboard_mode == CLIPBOARD_MOVE && explorer_move_path(E.clipboard_paths[i], destination) == 0)) {
+            pasted++;
+        } else {
+            failed++;
+            if (first_error[0] == '\0') {
+                snprintf(first_error, sizeof(first_error), "%s: %s", name, strerror(errno));
+            }
+        }
+    }
+
+    if (E.clipboard_mode == CLIPBOARD_MOVE && failed == 0) {
+        explorer_free_clipboard();
+    }
+    explorer_load_directory(E.cwd);
+    explorer_clear_marks();
+    if (failed == 0) {
+        explorer_set_status("Pasted %zu item%s", pasted, pasted == 1 ? "" : "s");
+    } else {
+        explorer_set_status("Pasted %zu item%s, %zu failed (%s)", pasted, pasted == 1 ? "" : "s", failed, first_error);
+    }
+}
+
+static void explorer_move_cursor(int direction, int mark)
+{
+    ExplorerEntry *entry;
+
+    if (E.entry_count == 0) {
+        return;
+    }
+    if (mark) {
+        entry = explorer_selected_entry();
+        if (explorer_entry_is_actionable(entry)) {
+            entry->marked = 1;
+        }
+    }
+    if (direction < 0 && E.selected > 0) {
+        E.selected--;
+    } else if (direction > 0 && E.selected + 1 < E.entry_count) {
+        E.selected++;
+    }
+    if (mark) {
+        entry = explorer_selected_entry();
+        if (explorer_entry_is_actionable(entry)) {
+            entry->marked = 1;
+        }
+        explorer_set_status("Marked %zu entries", explorer_marked_count());
+    }
 }
 
 static void explorer_scroll_to_cursor(void)
@@ -452,6 +915,7 @@ static void explorer_draw_entry(const ExplorerEntry *entry, int row, int selecte
     if (selected) {
         printf("\x1b[44;37m");
     }
+    printf("%c ", entry->marked ? '*' : ' ');
     explorer_draw_truncated(display_name, name_width);
     printf("  %-10s %10s  %-16s", perms, size_text, time_text);
     if (selected) {
@@ -466,25 +930,27 @@ static void explorer_draw_screen(void)
     int row;
     int name_width;
     char title[PATH_MAX + 64];
-    char right[64];
+    char right[96];
+    size_t marked;
 
     explorer_get_window_size(&E.rows, &E.cols);
     explorer_scroll_to_cursor();
     visible_rows = (size_t)(E.rows - 5);
-    name_width = E.cols - 46;
+    marked = explorer_marked_count();
+    name_width = E.cols - 48;
     if (name_width < 16) {
         name_width = 16;
     }
 
     printf("\x1b[?25l\x1b[2J\x1b[H");
     snprintf(title, sizeof(title), " BUDOSTACK Explorer  %s ", E.cwd);
-    snprintf(right, sizeof(right), " %zu/%zu ", E.entry_count == 0 ? 0 : E.selected + 1, E.entry_count);
+    snprintf(right, sizeof(right), " %zu/%zu  marked:%zu  clip:%zu ", E.entry_count == 0 ? 0 : E.selected + 1, E.entry_count, marked, E.clipboard_count);
     explorer_draw_bar_text(title, right, 1);
 
     printf("\x1b[2;1H+");
     explorer_draw_repeated('-', E.cols - 2);
     printf("+");
-    printf("\x1b[3;2H%-*s  %-10s %10s  %-16s", name_width, "Name", "Mode", "Size", "Modified");
+    printf("\x1b[3;2H  %-*s  %-10s %10s  %-16s", name_width, "Name", "Mode", "Size", "Modified");
 
     for (i = 0; i < visible_rows; i++) {
         row = (int)i + 4;
@@ -501,7 +967,7 @@ static void explorer_draw_screen(void)
     explorer_draw_repeated('-', E.cols - 2);
     printf("+");
     explorer_draw_bar_text(E.status, E.show_hidden ? " hidden:on " : " hidden:off ", E.rows - 2);
-    explorer_draw_bar_text(" ↑↓ Move  Enter/Open  ← Parent  e Edit  r Rename  d Delete  n Mkdir ", " h Hidden  q Quit ", E.rows);
+    explorer_draw_bar_text(" ↑↓ Move  Shift↑↓ Mark  Space Mark  ^A All  c Copy  m Move  p Paste ", " Enter Open  q Quit ", E.rows);
     fflush(stdout);
 }
 
@@ -706,15 +1172,17 @@ static void explorer_process_key(int key)
             break;
         case KEY_ARROW_UP:
         case 'k':
-            if (E.selected > 0) {
-                E.selected--;
-            }
+            explorer_move_cursor(-1, E.selection_mode);
             break;
         case KEY_ARROW_DOWN:
         case 'j':
-            if (E.selected + 1 < E.entry_count) {
-                E.selected++;
-            }
+            explorer_move_cursor(1, E.selection_mode);
+            break;
+        case KEY_SHIFT_UP:
+            explorer_move_cursor(-1, 1);
+            break;
+        case KEY_SHIFT_DOWN:
+            explorer_move_cursor(1, 1);
             break;
         case KEY_PAGE_UP:
             if (E.selected > visible_rows) {
@@ -742,10 +1210,36 @@ static void explorer_process_key(int key)
         case KEY_ARROW_RIGHT:
         case '\r':
         case '\n':
-            explorer_open_selected();
+            if (E.selection_mode) {
+                explorer_toggle_mark_selected();
+            } else {
+                explorer_open_selected();
+            }
             break;
         case KEY_ARROW_LEFT:
             explorer_go_parent();
+            break;
+        case CTRL_KEY('a'):
+            explorer_mark_all();
+            break;
+        case CTRL_KEY('t'):
+            E.selection_mode = !E.selection_mode;
+            explorer_set_status("Selection mode %s. Use arrows to mark ranges, Space/Enter to toggle entries.", E.selection_mode ? "on" : "off");
+            break;
+        case ' ':
+            explorer_toggle_mark_selected();
+            break;
+        case 'c':
+        case 'C':
+            explorer_set_clipboard(CLIPBOARD_COPY);
+            break;
+        case 'm':
+        case 'M':
+            explorer_set_clipboard(CLIPBOARD_MOVE);
+            break;
+        case 'p':
+        case 'P':
+            explorer_paste_clipboard();
             break;
         case 'h':
             E.show_hidden = !E.show_hidden;
@@ -765,7 +1259,7 @@ static void explorer_process_key(int key)
             explorer_edit_selected();
             break;
         default:
-            explorer_set_status("Shortcut: arrows move, Enter opens, e edits, r renames, d deletes, n creates, h toggles hidden, q quits.");
+            explorer_set_status("Shortcuts: Space mark, Ctrl+A all, Ctrl+T selection mode, c copy, m move, p paste, e edit, q quit.");
             break;
     }
 }
@@ -806,6 +1300,7 @@ int main(int argc, char **argv)
     }
 
     explorer_free_entries();
+    explorer_free_clipboard();
     printf("\x1b[2J\x1b[H\x1b[?25h");
     fflush(stdout);
     return EXIT_SUCCESS;

--- a/apps/explorer.c
+++ b/apps/explorer.c
@@ -1,0 +1,812 @@
+#define _XOPEN_SOURCE 700
+#define BUDOSTACK_LIST_NO_MAIN
+
+#include "../utilities/list.c"
+#include "../lib/terminal_layout.h"
+
+#include <ctype.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <termios.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#define CTRL_KEY(k) ((k) & 0x1f)
+#define EXPLORER_MIN_ROWS 12
+#define EXPLORER_MIN_COLS 60
+#define EXPLORER_STATUS_SIZE 256
+
+enum ExplorerKey {
+    KEY_ARROW_LEFT = 1000,
+    KEY_ARROW_RIGHT,
+    KEY_ARROW_UP,
+    KEY_ARROW_DOWN,
+    KEY_HOME,
+    KEY_END,
+    KEY_PAGE_UP,
+    KEY_PAGE_DOWN,
+    KEY_DELETE
+};
+
+typedef struct {
+    char *name;
+    char path[PATH_MAX];
+    mode_t mode;
+    off_t size;
+    time_t mtime;
+    int is_dir;
+} ExplorerEntry;
+
+typedef struct {
+    struct termios original_termios;
+    ExplorerEntry *entries;
+    size_t entry_count;
+    size_t selected;
+    size_t scroll;
+    char cwd[PATH_MAX];
+    char status[EXPLORER_STATUS_SIZE];
+    int rows;
+    int cols;
+    int show_hidden;
+    int running;
+    char edit_path[PATH_MAX];
+} ExplorerState;
+
+static ExplorerState E;
+
+static void explorer_set_status(const char *fmt, ...);
+
+static void explorer_die(const char *message)
+{
+    if (write(STDOUT_FILENO, "\x1b[?25h\x1b[0m\x1b[2J\x1b[H", strlen("\x1b[?25h\x1b[0m\x1b[2J\x1b[H")) < 0) {
+        perror("write");
+    }
+    perror(message);
+    exit(EXIT_FAILURE);
+}
+
+static void explorer_disable_raw_mode(void)
+{
+    if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &E.original_termios) == -1) {
+        perror("tcsetattr");
+    }
+    if (write(STDOUT_FILENO, "\x1b[?25h\x1b[0m", strlen("\x1b[?25h\x1b[0m")) < 0) {
+        perror("write");
+    }
+}
+
+static void explorer_enable_raw_mode(void)
+{
+    struct termios raw;
+
+    if (tcgetattr(STDIN_FILENO, &E.original_termios) == -1) {
+        explorer_die("tcgetattr");
+    }
+    atexit(explorer_disable_raw_mode);
+
+    raw = E.original_termios;
+    raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+    raw.c_oflag &= ~(OPOST);
+    raw.c_cflag |= (CS8);
+    raw.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
+    raw.c_cc[VMIN] = 0;
+    raw.c_cc[VTIME] = 1;
+
+    if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw) == -1) {
+        explorer_die("tcsetattr");
+    }
+}
+
+static int explorer_read_key(void)
+{
+    char c;
+    ssize_t nread;
+
+    do {
+        nread = read(STDIN_FILENO, &c, 1);
+    } while (nread == 0);
+
+    if (nread == -1) {
+        explorer_die("read");
+    }
+
+    if (c == '\x1b') {
+        char seq[3];
+
+        if (read(STDIN_FILENO, &seq[0], 1) != 1) {
+            return '\x1b';
+        }
+        if (read(STDIN_FILENO, &seq[1], 1) != 1) {
+            return '\x1b';
+        }
+
+        if (seq[0] == '[') {
+            if (seq[1] >= '0' && seq[1] <= '9') {
+                if (read(STDIN_FILENO, &seq[2], 1) != 1) {
+                    return '\x1b';
+                }
+                if (seq[2] == '~') {
+                    switch (seq[1]) {
+                        case '1':
+                        case '7':
+                            return KEY_HOME;
+                        case '3':
+                            return KEY_DELETE;
+                        case '4':
+                        case '8':
+                            return KEY_END;
+                        case '5':
+                            return KEY_PAGE_UP;
+                        case '6':
+                            return KEY_PAGE_DOWN;
+                    }
+                }
+            } else {
+                switch (seq[1]) {
+                    case 'A':
+                        return KEY_ARROW_UP;
+                    case 'B':
+                        return KEY_ARROW_DOWN;
+                    case 'C':
+                        return KEY_ARROW_RIGHT;
+                    case 'D':
+                        return KEY_ARROW_LEFT;
+                    case 'H':
+                        return KEY_HOME;
+                    case 'F':
+                        return KEY_END;
+                }
+            }
+        }
+        return '\x1b';
+    }
+
+    return c;
+}
+
+static int explorer_get_window_size(int *rows, int *cols)
+{
+    struct winsize ws;
+
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == -1 || ws.ws_col == 0 || ws.ws_row == 0) {
+        *rows = budostack_get_target_rows();
+        *cols = budostack_get_target_cols();
+    } else {
+        *rows = ws.ws_row;
+        *cols = ws.ws_col;
+    }
+
+    budostack_clamp_terminal_size(rows, cols);
+    if (*rows < EXPLORER_MIN_ROWS) {
+        *rows = EXPLORER_MIN_ROWS;
+    }
+    if (*cols < EXPLORER_MIN_COLS) {
+        *cols = EXPLORER_MIN_COLS;
+    }
+
+    return 0;
+}
+
+static void explorer_set_status(const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    vsnprintf(E.status, sizeof(E.status), fmt, ap);
+    E.status[sizeof(E.status) - 1] = '\0';
+    va_end(ap);
+}
+
+static void explorer_free_entries(void)
+{
+    size_t i;
+
+    for (i = 0; i < E.entry_count; i++) {
+        free(E.entries[i].name);
+    }
+    free(E.entries);
+    E.entries = NULL;
+    E.entry_count = 0;
+}
+
+static int explorer_entry_compare(const void *left, const void *right)
+{
+    const ExplorerEntry *a = left;
+    const ExplorerEntry *b = right;
+    int folded;
+
+    if (strcmp(a->name, "..") == 0) {
+        return -1;
+    }
+    if (strcmp(b->name, "..") == 0) {
+        return 1;
+    }
+    if (a->is_dir != b->is_dir) {
+        return b->is_dir - a->is_dir;
+    }
+
+    folded = strcasecmp(a->name, b->name);
+    if (folded != 0) {
+        return folded;
+    }
+    return strcmp(a->name, b->name);
+}
+
+static int explorer_add_entry(const char *dir_path, const char *name)
+{
+    ExplorerEntry *new_entries;
+    ExplorerEntry *entry;
+    struct stat st;
+    size_t new_count;
+    int written;
+
+    new_count = E.entry_count + 1;
+    new_entries = realloc(E.entries, new_count * sizeof(*E.entries));
+    if (new_entries == NULL) {
+        explorer_set_status("Out of memory while reading directory");
+        return -1;
+    }
+    E.entries = new_entries;
+    entry = &E.entries[E.entry_count];
+    memset(entry, 0, sizeof(*entry));
+
+    entry->name = strdup(name);
+    if (entry->name == NULL) {
+        explorer_set_status("Out of memory while reading directory");
+        return -1;
+    }
+
+    written = snprintf(entry->path, sizeof(entry->path), "%s/%s", dir_path, name);
+    if (written < 0 || (size_t)written >= sizeof(entry->path)) {
+        free(entry->name);
+        entry->name = NULL;
+        explorer_set_status("Path is too long: %s/%s", dir_path, name);
+        return -1;
+    }
+
+    if (lstat(entry->path, &st) == -1) {
+        free(entry->name);
+        entry->name = NULL;
+        explorer_set_status("Cannot stat %s: %s", entry->path, strerror(errno));
+        return -1;
+    }
+
+    entry->mode = st.st_mode;
+    entry->size = st.st_size;
+    entry->mtime = st.st_mtime;
+    entry->is_dir = S_ISDIR(st.st_mode);
+    E.entry_count = new_count;
+    return 0;
+}
+
+static int explorer_load_directory(const char *dir_path)
+{
+    DIR *dir;
+    struct dirent *entry;
+    char previous[PATH_MAX];
+    char target[PATH_MAX];
+
+    snprintf(previous, sizeof(previous), "%s", E.cwd);
+    snprintf(target, sizeof(target), "%s", dir_path);
+    target[sizeof(target) - 1] = '\0';
+    explorer_free_entries();
+
+    if (chdir(target) == -1) {
+        explorer_set_status("Cannot enter %s: %s", target, strerror(errno));
+        return -1;
+    }
+    if (getcwd(E.cwd, sizeof(E.cwd)) == NULL) {
+        explorer_set_status("Cannot read current directory: %s", strerror(errno));
+        if (chdir(previous) == -1) {
+            perror("chdir");
+        }
+        snprintf(E.cwd, sizeof(E.cwd), "%s", previous);
+        return -1;
+    }
+
+    dir = opendir(E.cwd);
+    if (dir == NULL) {
+        explorer_set_status("Cannot open %s: %s", E.cwd, strerror(errno));
+        if (chdir(previous) == -1) {
+            perror("chdir");
+        }
+        snprintf(E.cwd, sizeof(E.cwd), "%s", previous);
+        return -1;
+    }
+
+    if (strcmp(E.cwd, "/") != 0) {
+        if (explorer_add_entry(E.cwd, "..") == -1) {
+            closedir(dir);
+            return -1;
+        }
+    }
+
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        if (!E.show_hidden && entry->d_name[0] == '.') {
+            continue;
+        }
+        if (explorer_add_entry(E.cwd, entry->d_name) == -1) {
+            closedir(dir);
+            return -1;
+        }
+    }
+
+    closedir(dir);
+    qsort(E.entries, E.entry_count, sizeof(*E.entries), explorer_entry_compare);
+    E.selected = 0;
+    E.scroll = 0;
+    explorer_set_status("%zu entries. Enter opens, e edits via ./apps/edit, d deletes, r renames, n creates a folder.", E.entry_count);
+    return 0;
+}
+
+static ExplorerEntry *explorer_selected_entry(void)
+{
+    if (E.entry_count == 0 || E.selected >= E.entry_count) {
+        return NULL;
+    }
+    return &E.entries[E.selected];
+}
+
+static void explorer_scroll_to_cursor(void)
+{
+    size_t visible_rows;
+
+    visible_rows = (size_t)(E.rows - 5);
+    if (E.selected < E.scroll) {
+        E.scroll = E.selected;
+    }
+    if (E.selected >= E.scroll + visible_rows) {
+        E.scroll = E.selected - visible_rows + 1;
+    }
+}
+
+static void explorer_draw_repeated(char ch, int count)
+{
+    int i;
+
+    for (i = 0; i < count; i++) {
+        putchar(ch);
+    }
+}
+
+static void explorer_draw_truncated(const char *text, int width)
+{
+    int len;
+
+    if (width <= 0) {
+        return;
+    }
+    len = (int)strlen(text);
+    if (len <= width) {
+        printf("%s", text);
+        explorer_draw_repeated(' ', width - len);
+        return;
+    }
+    if (width <= 3) {
+        explorer_draw_repeated('.', width);
+        return;
+    }
+    printf("%.*s...", width - 3, text);
+}
+
+static void explorer_draw_bar_text(const char *left, const char *right, int row)
+{
+    int left_width;
+    int right_width;
+    int space;
+
+    left_width = (int)strlen(left);
+    right_width = (int)strlen(right);
+    space = E.cols - left_width - right_width;
+    if (space < 1) {
+        space = 1;
+    }
+
+    printf("\x1b[%d;1H\x1b[7m", row);
+    explorer_draw_truncated(left, E.cols - right_width - space);
+    explorer_draw_repeated(' ', space);
+    printf("%s", right);
+    printf("\x1b[0m");
+}
+
+static void explorer_draw_entry(const ExplorerEntry *entry, int row, int selected, int name_width)
+{
+    char display_name[PATH_MAX + 4];
+    char perms[11];
+    char size_value_raw[32];
+    char unit_raw[8];
+    char size_text[48];
+    char time_text[20];
+    struct tm *tm_info;
+
+    mode_to_string(entry->mode, perms);
+    if (entry->is_dir && strcmp(entry->name, "..") != 0) {
+        snprintf(display_name, sizeof(display_name), "[%s]", entry->name);
+    } else {
+        snprintf(display_name, sizeof(display_name), "%s", entry->name);
+    }
+
+    if (entry->is_dir) {
+        snprintf(size_text, sizeof(size_text), "<DIR>");
+    } else {
+        format_size(entry->size, size_value_raw, sizeof(size_value_raw), unit_raw, sizeof(unit_raw));
+        snprintf(size_text, sizeof(size_text), "%s %s", size_value_raw, unit_raw);
+    }
+
+    tm_info = localtime(&entry->mtime);
+    if (tm_info != NULL) {
+        strftime(time_text, sizeof(time_text), "%Y-%m-%d %H:%M", tm_info);
+    } else {
+        snprintf(time_text, sizeof(time_text), "unknown");
+    }
+
+    printf("\x1b[%d;2H", row);
+    if (selected) {
+        printf("\x1b[44;37m");
+    }
+    explorer_draw_truncated(display_name, name_width);
+    printf("  %-10s %10s  %-16s", perms, size_text, time_text);
+    if (selected) {
+        printf("\x1b[0m");
+    }
+}
+
+static void explorer_draw_screen(void)
+{
+    size_t i;
+    size_t visible_rows;
+    int row;
+    int name_width;
+    char title[PATH_MAX + 64];
+    char right[64];
+
+    explorer_get_window_size(&E.rows, &E.cols);
+    explorer_scroll_to_cursor();
+    visible_rows = (size_t)(E.rows - 5);
+    name_width = E.cols - 46;
+    if (name_width < 16) {
+        name_width = 16;
+    }
+
+    printf("\x1b[?25l\x1b[2J\x1b[H");
+    snprintf(title, sizeof(title), " BUDOSTACK Explorer  %s ", E.cwd);
+    snprintf(right, sizeof(right), " %zu/%zu ", E.entry_count == 0 ? 0 : E.selected + 1, E.entry_count);
+    explorer_draw_bar_text(title, right, 1);
+
+    printf("\x1b[2;1H+");
+    explorer_draw_repeated('-', E.cols - 2);
+    printf("+");
+    printf("\x1b[3;2H%-*s  %-10s %10s  %-16s", name_width, "Name", "Mode", "Size", "Modified");
+
+    for (i = 0; i < visible_rows; i++) {
+        row = (int)i + 4;
+        printf("\x1b[%d;1H|", row);
+        explorer_draw_repeated(' ', E.cols - 2);
+        printf("|");
+        if (E.scroll + i < E.entry_count) {
+            explorer_draw_entry(&E.entries[E.scroll + i], row, E.scroll + i == E.selected, name_width);
+        }
+    }
+
+    row = E.rows - 1;
+    printf("\x1b[%d;1H+", row);
+    explorer_draw_repeated('-', E.cols - 2);
+    printf("+");
+    explorer_draw_bar_text(E.status, E.show_hidden ? " hidden:on " : " hidden:off ", E.rows - 2);
+    explorer_draw_bar_text(" ↑↓ Move  Enter/Open  ← Parent  e Edit  r Rename  d Delete  n Mkdir ", " h Hidden  q Quit ", E.rows);
+    fflush(stdout);
+}
+
+static int explorer_prompt(const char *prompt, char *buffer, size_t buffer_size)
+{
+    size_t len;
+    int c;
+
+    if (buffer_size == 0) {
+        return -1;
+    }
+    len = strlen(buffer);
+    for (;;) {
+        explorer_set_status("%s%s", prompt, buffer);
+        explorer_draw_screen();
+        c = explorer_read_key();
+        if (c == '\r' || c == '\n') {
+            buffer[buffer_size - 1] = '\0';
+            return len > 0 ? 0 : -1;
+        }
+        if (c == '\x1b' || c == CTRL_KEY('q')) {
+            return -1;
+        }
+        if (c == 127 || c == CTRL_KEY('h') || c == KEY_DELETE) {
+            if (len > 0) {
+                len--;
+                buffer[len] = '\0';
+            }
+            continue;
+        }
+        if (c >= 0 && c <= UCHAR_MAX && isprint((unsigned char)c) && len + 1 < buffer_size) {
+            buffer[len] = (char)c;
+            len++;
+            buffer[len] = '\0';
+        }
+    }
+}
+
+static void explorer_open_selected(void)
+{
+    ExplorerEntry *entry;
+
+    entry = explorer_selected_entry();
+    if (entry == NULL) {
+        explorer_set_status("No entry selected");
+        return;
+    }
+    if (entry->is_dir) {
+        explorer_load_directory(entry->path);
+    } else {
+        explorer_set_status("File: %s. Press e to edit, d to delete, r to rename.", entry->name);
+    }
+}
+
+static void explorer_go_parent(void)
+{
+    if (strcmp(E.cwd, "/") == 0) {
+        explorer_set_status("Already at filesystem root");
+        return;
+    }
+    explorer_load_directory("..");
+}
+
+static void explorer_delete_selected(void)
+{
+    ExplorerEntry *entry;
+    char prompt[PATH_MAX + 64];
+    char answer[8];
+    char deleted_name[PATH_MAX];
+
+    entry = explorer_selected_entry();
+    if (entry == NULL || strcmp(entry->name, "..") == 0) {
+        explorer_set_status("Choose a normal file or empty directory to delete");
+        return;
+    }
+
+    snprintf(prompt, sizeof(prompt), "Delete %s? Type y: ", entry->name);
+    answer[0] = '\0';
+    if (explorer_prompt(prompt, answer, sizeof(answer)) == -1 || strcmp(answer, "y") != 0) {
+        explorer_set_status("Delete canceled");
+        return;
+    }
+
+    snprintf(deleted_name, sizeof(deleted_name), "%s", entry->name);
+
+    if (entry->is_dir) {
+        if (rmdir(entry->path) == -1) {
+            explorer_set_status("Cannot delete directory %s: %s", entry->name, strerror(errno));
+            return;
+        }
+    } else if (unlink(entry->path) == -1) {
+        explorer_set_status("Cannot delete %s: %s", entry->name, strerror(errno));
+        return;
+    }
+
+    explorer_load_directory(E.cwd);
+    explorer_set_status("Deleted %s", deleted_name);
+}
+
+static void explorer_rename_selected(void)
+{
+    ExplorerEntry *entry;
+    char new_name[PATH_MAX];
+    char new_path[PATH_MAX];
+    int written;
+
+    entry = explorer_selected_entry();
+    if (entry == NULL || strcmp(entry->name, "..") == 0) {
+        explorer_set_status("Choose a normal file or directory to rename");
+        return;
+    }
+
+    snprintf(new_name, sizeof(new_name), "%s", entry->name);
+    if (explorer_prompt("Rename to: ", new_name, sizeof(new_name)) == -1) {
+        explorer_set_status("Rename canceled");
+        return;
+    }
+
+    written = snprintf(new_path, sizeof(new_path), "%s/%s", E.cwd, new_name);
+    if (written < 0 || (size_t)written >= sizeof(new_path)) {
+        explorer_set_status("New path is too long");
+        return;
+    }
+    if (rename(entry->path, new_path) == -1) {
+        explorer_set_status("Cannot rename %s: %s", entry->name, strerror(errno));
+        return;
+    }
+    explorer_load_directory(E.cwd);
+    explorer_set_status("Renamed to %s", new_name);
+}
+
+static void explorer_make_directory(void)
+{
+    char name[PATH_MAX];
+    char path[PATH_MAX];
+    int written;
+
+    name[0] = '\0';
+    if (explorer_prompt("New directory name: ", name, sizeof(name)) == -1) {
+        explorer_set_status("Mkdir canceled");
+        return;
+    }
+
+    written = snprintf(path, sizeof(path), "%s/%s", E.cwd, name);
+    if (written < 0 || (size_t)written >= sizeof(path)) {
+        explorer_set_status("Directory path is too long");
+        return;
+    }
+    if (mkdir(path, 0777) == -1) {
+        explorer_set_status("Cannot create %s: %s", name, strerror(errno));
+        return;
+    }
+    explorer_load_directory(E.cwd);
+    explorer_set_status("Created directory %s", name);
+}
+
+static void explorer_edit_selected(void)
+{
+    ExplorerEntry *entry;
+    pid_t pid;
+    int status;
+
+    entry = explorer_selected_entry();
+    if (entry == NULL || entry->is_dir) {
+        explorer_set_status("Choose a file to edit");
+        return;
+    }
+
+    explorer_disable_raw_mode();
+    printf("\x1b[2J\x1b[H");
+    fflush(stdout);
+    pid = fork();
+    if (pid == -1) {
+        explorer_enable_raw_mode();
+        explorer_set_status("Cannot start editor: %s", strerror(errno));
+        return;
+    }
+    if (pid == 0) {
+        execl(E.edit_path, "edit", entry->path, (char *)NULL);
+        execlp("edit", "edit", entry->path, (char *)NULL);
+        perror("edit");
+        _exit(EXIT_FAILURE);
+    }
+    if (waitpid(pid, &status, 0) == -1) {
+        explorer_set_status("Editor wait failed: %s", strerror(errno));
+    } else {
+        explorer_set_status("Editor exited with status %d", status);
+    }
+    explorer_enable_raw_mode();
+    explorer_load_directory(E.cwd);
+}
+
+static void explorer_process_key(int key)
+{
+    size_t visible_rows;
+
+    visible_rows = (size_t)(E.rows - 5);
+    switch (key) {
+        case CTRL_KEY('q'):
+        case 'q':
+            E.running = 0;
+            break;
+        case KEY_ARROW_UP:
+        case 'k':
+            if (E.selected > 0) {
+                E.selected--;
+            }
+            break;
+        case KEY_ARROW_DOWN:
+        case 'j':
+            if (E.selected + 1 < E.entry_count) {
+                E.selected++;
+            }
+            break;
+        case KEY_PAGE_UP:
+            if (E.selected > visible_rows) {
+                E.selected -= visible_rows;
+            } else {
+                E.selected = 0;
+            }
+            break;
+        case KEY_PAGE_DOWN:
+            if (E.entry_count > 0) {
+                E.selected += visible_rows;
+                if (E.selected >= E.entry_count) {
+                    E.selected = E.entry_count - 1;
+                }
+            }
+            break;
+        case KEY_HOME:
+            E.selected = 0;
+            break;
+        case KEY_END:
+            if (E.entry_count > 0) {
+                E.selected = E.entry_count - 1;
+            }
+            break;
+        case KEY_ARROW_RIGHT:
+        case '\r':
+        case '\n':
+            explorer_open_selected();
+            break;
+        case KEY_ARROW_LEFT:
+            explorer_go_parent();
+            break;
+        case 'h':
+            E.show_hidden = !E.show_hidden;
+            explorer_load_directory(E.cwd);
+            break;
+        case 'd':
+        case KEY_DELETE:
+            explorer_delete_selected();
+            break;
+        case 'r':
+            explorer_rename_selected();
+            break;
+        case 'n':
+            explorer_make_directory();
+            break;
+        case 'e':
+            explorer_edit_selected();
+            break;
+        default:
+            explorer_set_status("Shortcut: arrows move, Enter opens, e edits, r renames, d deletes, n creates, h toggles hidden, q quits.");
+            break;
+    }
+}
+
+static void explorer_handle_signal(int signo)
+{
+    (void)signo;
+    E.running = 0;
+}
+
+int main(int argc, char **argv)
+{
+    const char *start_dir;
+
+    setlocale(LC_CTYPE, "");
+    memset(&E, 0, sizeof(E));
+    E.running = 1;
+    start_dir = argc > 1 ? argv[1] : ".";
+
+    signal(SIGTERM, explorer_handle_signal);
+    signal(SIGINT, explorer_handle_signal);
+    explorer_enable_raw_mode();
+
+    if (getcwd(E.cwd, sizeof(E.cwd)) == NULL) {
+        explorer_die("getcwd");
+    }
+    if (snprintf(E.edit_path, sizeof(E.edit_path), "%s/apps/edit", E.cwd) < 0) {
+        explorer_die("snprintf");
+    }
+    E.edit_path[sizeof(E.edit_path) - 1] = '\0';
+    if (explorer_load_directory(start_dir) == -1) {
+        explorer_die("explorer_load_directory");
+    }
+
+    while (E.running) {
+        explorer_draw_screen();
+        explorer_process_key(explorer_read_key());
+    }
+
+    explorer_free_entries();
+    printf("\x1b[2J\x1b[H\x1b[?25h");
+    fflush(stdout);
+    return EXIT_SUCCESS;
+}

--- a/apps/explorer.c
+++ b/apps/explorer.c
@@ -819,7 +819,7 @@ static void explorer_scroll_to_cursor(void)
 {
     size_t visible_rows;
 
-    visible_rows = (size_t)(E.rows - 5);
+    visible_rows = (size_t)(E.rows - 6);
     if (E.selected < E.scroll) {
         E.scroll = E.selected;
     }
@@ -1001,7 +1001,7 @@ static void explorer_draw_screen(void)
 
     explorer_get_window_size(&E.rows, &E.cols);
     explorer_scroll_to_cursor();
-    visible_rows = (size_t)(E.rows - 5);
+    visible_rows = (size_t)(E.rows - 6);
     marked = explorer_marked_count();
     name_width = E.cols - 45;
     if (name_width < 8) {
@@ -1033,7 +1033,7 @@ static void explorer_draw_screen(void)
     explorer_draw_repeated('-', E.cols - 2);
     printf("+");
     explorer_draw_bar_text(E.status, E.show_hidden ? " hidden:on " : " hidden:off ", E.rows - 2);
-    explorer_draw_bar_text(" ↑↓Move EnterOpen SpaceMark ^TSelect ^AAll/None cCopy mMove pPaste ", " qQuit ", E.rows);
+    explorer_draw_bar_text("nav open up mark sel all cp mv paste new del ren edit hid quit", "", E.rows);
     fflush(stdout);
 }
 
@@ -1230,7 +1230,7 @@ static void explorer_process_key(int key)
 {
     size_t visible_rows;
 
-    visible_rows = (size_t)(E.rows - 5);
+    visible_rows = (size_t)(E.rows - 6);
     switch (key) {
         case CTRL_KEY('q'):
         case 'q':

--- a/documents/help.txt
+++ b/documents/help.txt
@@ -169,6 +169,8 @@
 
   dungeon  : Role-Playing tool, type 'dungeon map.bmp' or 'dungeon map.dng'.
   editprof.: Full name 'editprofile'. App for editing color scheme presets.
+  explorer : Norton Commander-style file explorer with arrows, Space marks,
+             Ctrl+A mark/unmark all, c copy, m move, and p paste.
   paint    : ASCII paint application to edit bitmaps.
   pixart   : Turn images into pixel art and assets to your apps.
   psfedit  : Font editor for .psf fonts.

--- a/documents/help.txt
+++ b/documents/help.txt
@@ -169,8 +169,8 @@
 
   dungeon  : Role-Playing tool, type 'dungeon map.bmp' or 'dungeon map.dng'.
   editprof.: Full name 'editprofile'. App for editing color scheme presets.
-  explorer : Norton Commander-style file explorer with arrows, Space marks,
-             Ctrl+A mark/unmark all, c copy, m move, and p paste.
+  explorer : Norton Commander-style file explorer: nav/open/up, mark/select,
+             all/none, cp, mv, paste, new, del, ren, edit, hid, quit.
   paint    : ASCII paint application to edit bitmaps.
   pixart   : Turn images into pixel art and assets to your apps.
   psfedit  : Font editor for .psf fonts.

--- a/utilities/list.c
+++ b/utilities/list.c
@@ -606,6 +606,7 @@ void print_help(void) {
     printf("\n");
 }
 
+#ifndef BUDOSTACK_LIST_NO_MAIN
 int main(int argc, char *argv[]) {
     setlocale(LC_CTYPE, "");
 
@@ -707,3 +708,4 @@ int main(int argc, char *argv[]) {
 
     return EXIT_SUCCESS;
 }
+#endif


### PR DESCRIPTION
### Motivation

- Provide a Norton/Midnight-Commander-style interactive terminal file explorer as an app to let users navigate and operate on the filesystem inside Budostack.
- Reuse existing formatting and file-info helpers from the `list` utility to avoid duplicating code and keep a consistent listing format.

### Description

- Add `apps/explorer.c`, a raw-terminal, arrow-key driven explorer that draws a framed file table with selection highlighting, status and shortcut bars, and implements operations for open, edit (`apps/edit`), rename, delete, mkdir, and toggle-hidden.
- Make `utilities/list.c` includable by wrapping its standalone `main` with `#ifndef BUDOSTACK_LIST_NO_MAIN` and define `BUDOSTACK_LIST_NO_MAIN` in the explorer before including it so explorer reuses list helpers.
- Implement terminal raw mode and window-size handling via `termios` and `lib/terminal_layout.h`, and add safer string/EOF handling and small portability fixes (added `stdarg.h`, used `strlen()` for write lengths, adjusted buffer sizes and `isprint` casts).
- Add selection/scroll management, directory loading/sorting (folders first), and robust path handling with `PATH_MAX` checks and snprintf bounds checks.

### Testing

- Ran `make clean all` and the full build completed successfully including `apps/explorer` with no warnings or errors.
- Automated PTY smoke test launched `./apps/explorer .`, sent `q` to quit, and verified the program started and exited cleanly (captured output during the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271e17a3808327a4915777d0239e60)