### PR TITLE
Improve stats CPU utilization measurement

### DIFF
--- a/apps/stats.c
+++ b/apps/stats.c
@@ -6,11 +6,12 @@
 #include <sys/statvfs.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <errno.h>
 #include <string.h>
 
 // Function to get battery charge (if available)
 // Returns battery capacity (0–100) if found, or -1 if no battery is found.
-int get_battery_charge(void) {
+static int get_battery_charge(void) {
     DIR *dir = opendir("/sys/class/power_supply");
     if (!dir) {
         return -1;
@@ -52,17 +53,121 @@ int get_battery_charge(void) {
     return battery;
 }
 
-static int read_cpu_stats(unsigned long long *user, unsigned long long *nice,
-                          unsigned long long *system, unsigned long long *idle,
-                          unsigned long long *iowait, unsigned long long *irq,
-                          unsigned long long *softirq, unsigned long long *steal) {
+struct CpuTimes {
+    unsigned long long user;
+    unsigned long long nice;
+    unsigned long long system;
+    unsigned long long idle;
+    unsigned long long iowait;
+    unsigned long long irq;
+    unsigned long long softirq;
+    unsigned long long steal;
+};
+
+struct CpuMeasurement {
+    double mean;
+    double min;
+    double max;
+    int samples;
+};
+
+static int read_cpu_stats(struct CpuTimes *stats) {
     FILE *fp = fopen("/proc/stat", "r");
-    if (!fp)
+    if (!fp) {
         return -1;
+    }
+
     int ret = fscanf(fp, "cpu  %llu %llu %llu %llu %llu %llu %llu %llu",
-                     user, nice, system, idle, iowait, irq, softirq, steal);
+                     &stats->user, &stats->nice, &stats->system, &stats->idle,
+                     &stats->iowait, &stats->irq, &stats->softirq, &stats->steal);
     fclose(fp);
     return (ret == 8) ? 0 : -1;
+}
+
+static void sleep_interval(long nanoseconds) {
+    struct timespec remaining;
+    struct timespec request;
+
+    request.tv_sec = nanoseconds / 1000000000L;
+    request.tv_nsec = nanoseconds % 1000000000L;
+
+    while (nanosleep(&request, &remaining) == -1) {
+        if (errno != EINTR) {
+            return;
+        }
+        request = remaining;
+    }
+}
+
+static int cpu_usage_between(const struct CpuTimes *before,
+                             const struct CpuTimes *after,
+                             double *usage) {
+    unsigned long long total_before = before->user + before->nice + before->system +
+                                      before->idle + before->iowait + before->irq +
+                                      before->softirq + before->steal;
+    unsigned long long total_after = after->user + after->nice + after->system +
+                                     after->idle + after->iowait + after->irq +
+                                     after->softirq + after->steal;
+    unsigned long long idle_before = before->idle + before->iowait;
+    unsigned long long idle_after = after->idle + after->iowait;
+    unsigned long long delta_total = total_after - total_before;
+    unsigned long long delta_idle = idle_after - idle_before;
+
+    if (delta_total == 0 || delta_total < delta_idle) {
+        return -1;
+    }
+
+    *usage = (double)(delta_total - delta_idle) * 100.0 / (double)delta_total;
+    return 0;
+}
+
+static int measure_cpu_usage(struct CpuMeasurement *measurement) {
+    enum {
+        sample_count = 10
+    };
+    const long sample_interval_ns = 500000000L;
+    struct CpuTimes before;
+    double sum = 0.0;
+
+    measurement->mean = 0.0;
+    measurement->min = 0.0;
+    measurement->max = 0.0;
+    measurement->samples = 0;
+
+    if (read_cpu_stats(&before) != 0) {
+        return -1;
+    }
+
+    printf("Measuring CPU utilization for 5 seconds...\n");
+    for (int sample = 1; sample <= sample_count; sample++) {
+        struct CpuTimes after;
+        double usage;
+
+        sleep_interval(sample_interval_ns);
+        if (read_cpu_stats(&after) != 0) {
+            return -1;
+        }
+        if (cpu_usage_between(&before, &after, &usage) == 0) {
+            if (measurement->samples == 0 || usage < measurement->min) {
+                measurement->min = usage;
+            }
+            if (measurement->samples == 0 || usage > measurement->max) {
+                measurement->max = usage;
+            }
+            sum += usage;
+            measurement->samples++;
+        }
+        before = after;
+        printf("Measurement progress: %d%%\n", sample * 10);
+        fflush(stdout);
+    }
+
+    if (measurement->samples == 0) {
+        return -1;
+    }
+
+    measurement->mean = sum / (double)measurement->samples;
+    return 0;
 }
 
 int main(void) {
@@ -91,27 +196,12 @@ int main(void) {
         fclose(fp);
     }
 
-    unsigned long long user1, nice1, system1, idle1, iowait1, irq1, softirq1, steal1;
-    unsigned long long user2, nice2, system2, idle2, iowait2, irq2, softirq2, steal2;
-    double cpu_usage = -1.0;
-    if (read_cpu_stats(&user1, &nice1, &system1, &idle1, &iowait1, &irq1, &softirq1, &steal1) == 0) {
-        struct timespec req = { .tv_sec = 0, .tv_nsec = 100000000 };
-        nanosleep(&req, NULL);
-        if (read_cpu_stats(&user2, &nice2, &system2, &idle2, &iowait2, &irq2, &softirq2, &steal2) == 0) {
-            unsigned long long total1 = user1 + nice1 + system1 + idle1 + iowait1 + irq1 + softirq1 + steal1;
-            unsigned long long total2 = user2 + nice2 + system2 + idle2 + iowait2 + irq2 + softirq2 + steal2;
-            unsigned long long delta_total = total2 - total1;
-            unsigned long long delta_idle = (idle2 + iowait2) - (idle1 + iowait1);
-            if (delta_total != 0 && delta_total >= delta_idle) {
-                cpu_usage = (double)(delta_total - delta_idle) * 100.0 / delta_total;
-            }
-        }
-    }
-
-    if (cpu_usage >= 0.0) {
-        printf("CPU Average Utilization: %.1f%%\n", cpu_usage);
+    struct CpuMeasurement cpu_measurement;
+    if (measure_cpu_usage(&cpu_measurement) == 0) {
+        printf("CPU Utilization (5 sec): mean %.1f%% / min %.1f%% / max %.1f%%\n",
+               cpu_measurement.mean, cpu_measurement.min, cpu_measurement.max);
     } else {
-        printf("CPU Average Utilization: N/A\n");
+        printf("CPU Utilization (5 sec): N/A\n");
     }
 
     now = time(NULL);

--- a/apps/stats.c
+++ b/apps/stats.c
@@ -64,16 +64,11 @@ struct CpuTimes {
     unsigned long long steal;
 };
 
-struct LoadMeasurement {
+struct CpuMeasurement {
     double mean;
     double min;
     double max;
     int samples;
-};
-
-struct GpuSource {
-    char busy_path[512];
-    int available;
 };
 
 static int read_cpu_stats(struct CpuTimes *stats) {
@@ -126,146 +121,52 @@ static int cpu_usage_between(const struct CpuTimes *before,
     return 0;
 }
 
-static void add_load_sample(struct LoadMeasurement *measurement,
-                            double value,
-                            double *sum) {
-    if (measurement->samples == 0 || value < measurement->min) {
-        measurement->min = value;
-    }
-    if (measurement->samples == 0 || value > measurement->max) {
-        measurement->max = value;
-    }
-    *sum += value;
-    measurement->samples++;
-}
-
-static void reset_load_measurement(struct LoadMeasurement *measurement) {
-    measurement->mean = 0.0;
-    measurement->min = 0.0;
-    measurement->max = 0.0;
-    measurement->samples = 0;
-}
-
-static int is_drm_card_name(const char *name) {
-    if (strncmp(name, "card", 4) != 0) {
-        return 0;
-    }
-    return name[4] >= '0' && name[4] <= '9';
-}
-
-static int read_gpu_busy_percent(const char *path, double *usage) {
-    FILE *fp = fopen(path, "r");
-    int percent;
-
-    if (!fp) {
-        return -1;
-    }
-
-    if (fscanf(fp, "%d", &percent) != 1) {
-        fclose(fp);
-        return -1;
-    }
-    fclose(fp);
-
-    if (percent < 0 || percent > 100) {
-        return -1;
-    }
-
-    *usage = (double)percent;
-    return 0;
-}
-
-static void find_gpu_source(struct GpuSource *source) {
-    DIR *dir = opendir("/sys/class/drm");
-    struct dirent *entry;
-
-    source->busy_path[0] = '\0';
-    source->available = 0;
-
-    if (!dir) {
-        return;
-    }
-
-    while ((entry = readdir(dir)) != NULL) {
-        char candidate[512];
-        double usage;
-        int written;
-
-        if (!is_drm_card_name(entry->d_name)) {
-            continue;
-        }
-
-        written = snprintf(candidate, sizeof(candidate),
-                           "/sys/class/drm/%s/device/gpu_busy_percent",
-                           entry->d_name);
-        if (written < 0 || (size_t)written >= sizeof(candidate)) {
-            continue;
-        }
-
-        if (read_gpu_busy_percent(candidate, &usage) == 0) {
-            snprintf(source->busy_path, sizeof(source->busy_path), "%s", candidate);
-            source->available = 1;
-            break;
-        }
-    }
-
-    closedir(dir);
-}
-
-static int measure_load(struct LoadMeasurement *cpu_measurement,
-                        struct LoadMeasurement *gpu_measurement,
-                        int *gpu_available) {
+static int measure_cpu_usage(struct CpuMeasurement *measurement) {
     enum {
         sample_count = 10
     };
     const long sample_interval_ns = 500000000L;
     struct CpuTimes before;
-    struct GpuSource gpu_source;
-    double cpu_sum = 0.0;
-    double gpu_sum = 0.0;
+    double sum = 0.0;
 
-    reset_load_measurement(cpu_measurement);
-    reset_load_measurement(gpu_measurement);
-    *gpu_available = 0;
+    measurement->mean = 0.0;
+    measurement->min = 0.0;
+    measurement->max = 0.0;
+    measurement->samples = 0;
 
     if (read_cpu_stats(&before) != 0) {
         return -1;
     }
 
-    find_gpu_source(&gpu_source);
-    printf("Measuring CPU/GPU utilization for 5 seconds...\n");
+    printf("Measuring CPU utilization for 5 seconds...\n");
     for (int sample = 1; sample <= sample_count; sample++) {
         struct CpuTimes after;
-        double cpu_usage;
-        double gpu_usage;
+        double usage;
 
         sleep_interval(sample_interval_ns);
         if (read_cpu_stats(&after) != 0) {
             return -1;
         }
-        if (cpu_usage_between(&before, &after, &cpu_usage) == 0) {
-            add_load_sample(cpu_measurement, cpu_usage, &cpu_sum);
+        if (cpu_usage_between(&before, &after, &usage) == 0) {
+            if (measurement->samples == 0 || usage < measurement->min) {
+                measurement->min = usage;
+            }
+            if (measurement->samples == 0 || usage > measurement->max) {
+                measurement->max = usage;
+            }
+            sum += usage;
+            measurement->samples++;
         }
         before = after;
-
-        if (gpu_source.available &&
-            read_gpu_busy_percent(gpu_source.busy_path, &gpu_usage) == 0) {
-            add_load_sample(gpu_measurement, gpu_usage, &gpu_sum);
-        }
-
         printf("Measurement progress: %d%%\n", sample * 10);
         fflush(stdout);
     }
 
-    if (cpu_measurement->samples == 0) {
+    if (measurement->samples == 0) {
         return -1;
     }
 
-    cpu_measurement->mean = cpu_sum / (double)cpu_measurement->samples;
-    if (gpu_measurement->samples > 0) {
-        gpu_measurement->mean = gpu_sum / (double)gpu_measurement->samples;
-        *gpu_available = 1;
-    }
+    measurement->mean = sum / (double)measurement->samples;
     return 0;
 }
 
@@ -295,22 +196,12 @@ int main(void) {
         fclose(fp);
     }
 
-    struct LoadMeasurement cpu_measurement;
-    struct LoadMeasurement gpu_measurement;
-    int gpu_available;
-
-    if (measure_load(&cpu_measurement, &gpu_measurement, &gpu_available) == 0) {
+    struct CpuMeasurement cpu_measurement;
+    if (measure_cpu_usage(&cpu_measurement) == 0) {
         printf("CPU Utilization (5 sec): mean %.1f%% / min %.1f%% / max %.1f%%\n",
                cpu_measurement.mean, cpu_measurement.min, cpu_measurement.max);
-        if (gpu_available) {
-            printf("GPU Utilization (5 sec): mean %.1f%% / min %.1f%% / max %.1f%%\n",
-                   gpu_measurement.mean, gpu_measurement.min, gpu_measurement.max);
-        } else {
-            printf("GPU Utilization (5 sec): N/A\n");
-        }
     } else {
         printf("CPU Utilization (5 sec): N/A\n");
-        printf("GPU Utilization (5 sec): N/A\n");
     }
 
     now = time(NULL);

--- a/apps/stats.c
+++ b/apps/stats.c
@@ -64,11 +64,16 @@ struct CpuTimes {
     unsigned long long steal;
 };
 
-struct CpuMeasurement {
+struct LoadMeasurement {
     double mean;
     double min;
     double max;
     int samples;
+};
+
+struct GpuSource {
+    char busy_path[512];
+    int available;
 };
 
 static int read_cpu_stats(struct CpuTimes *stats) {
@@ -121,52 +126,146 @@ static int cpu_usage_between(const struct CpuTimes *before,
     return 0;
 }
 
-static int measure_cpu_usage(struct CpuMeasurement *measurement) {
+static void add_load_sample(struct LoadMeasurement *measurement,
+                            double value,
+                            double *sum) {
+    if (measurement->samples == 0 || value < measurement->min) {
+        measurement->min = value;
+    }
+    if (measurement->samples == 0 || value > measurement->max) {
+        measurement->max = value;
+    }
+    *sum += value;
+    measurement->samples++;
+}
+
+static void reset_load_measurement(struct LoadMeasurement *measurement) {
+    measurement->mean = 0.0;
+    measurement->min = 0.0;
+    measurement->max = 0.0;
+    measurement->samples = 0;
+}
+
+static int is_drm_card_name(const char *name) {
+    if (strncmp(name, "card", 4) != 0) {
+        return 0;
+    }
+    return name[4] >= '0' && name[4] <= '9';
+}
+
+static int read_gpu_busy_percent(const char *path, double *usage) {
+    FILE *fp = fopen(path, "r");
+    int percent;
+
+    if (!fp) {
+        return -1;
+    }
+
+    if (fscanf(fp, "%d", &percent) != 1) {
+        fclose(fp);
+        return -1;
+    }
+    fclose(fp);
+
+    if (percent < 0 || percent > 100) {
+        return -1;
+    }
+
+    *usage = (double)percent;
+    return 0;
+}
+
+static void find_gpu_source(struct GpuSource *source) {
+    DIR *dir = opendir("/sys/class/drm");
+    struct dirent *entry;
+
+    source->busy_path[0] = '\0';
+    source->available = 0;
+
+    if (!dir) {
+        return;
+    }
+
+    while ((entry = readdir(dir)) != NULL) {
+        char candidate[512];
+        double usage;
+        int written;
+
+        if (!is_drm_card_name(entry->d_name)) {
+            continue;
+        }
+
+        written = snprintf(candidate, sizeof(candidate),
+                           "/sys/class/drm/%s/device/gpu_busy_percent",
+                           entry->d_name);
+        if (written < 0 || (size_t)written >= sizeof(candidate)) {
+            continue;
+        }
+
+        if (read_gpu_busy_percent(candidate, &usage) == 0) {
+            snprintf(source->busy_path, sizeof(source->busy_path), "%s", candidate);
+            source->available = 1;
+            break;
+        }
+    }
+
+    closedir(dir);
+}
+
+static int measure_load(struct LoadMeasurement *cpu_measurement,
+                        struct LoadMeasurement *gpu_measurement,
+                        int *gpu_available) {
     enum {
         sample_count = 10
     };
     const long sample_interval_ns = 500000000L;
     struct CpuTimes before;
-    double sum = 0.0;
+    struct GpuSource gpu_source;
+    double cpu_sum = 0.0;
+    double gpu_sum = 0.0;
 
-    measurement->mean = 0.0;
-    measurement->min = 0.0;
-    measurement->max = 0.0;
-    measurement->samples = 0;
+    reset_load_measurement(cpu_measurement);
+    reset_load_measurement(gpu_measurement);
+    *gpu_available = 0;
 
     if (read_cpu_stats(&before) != 0) {
         return -1;
     }
 
-    printf("Measuring CPU utilization for 5 seconds...\n");
+    find_gpu_source(&gpu_source);
+    printf("Measuring CPU/GPU utilization for 5 seconds...\n");
     for (int sample = 1; sample <= sample_count; sample++) {
         struct CpuTimes after;
-        double usage;
+        double cpu_usage;
+        double gpu_usage;
 
         sleep_interval(sample_interval_ns);
         if (read_cpu_stats(&after) != 0) {
             return -1;
         }
-        if (cpu_usage_between(&before, &after, &usage) == 0) {
-            if (measurement->samples == 0 || usage < measurement->min) {
-                measurement->min = usage;
-            }
-            if (measurement->samples == 0 || usage > measurement->max) {
-                measurement->max = usage;
-            }
-            sum += usage;
-            measurement->samples++;
+        if (cpu_usage_between(&before, &after, &cpu_usage) == 0) {
+            add_load_sample(cpu_measurement, cpu_usage, &cpu_sum);
         }
         before = after;
+
+        if (gpu_source.available &&
+            read_gpu_busy_percent(gpu_source.busy_path, &gpu_usage) == 0) {
+            add_load_sample(gpu_measurement, gpu_usage, &gpu_sum);
+        }
+
         printf("Measurement progress: %d%%\n", sample * 10);
         fflush(stdout);
     }
 
-    if (measurement->samples == 0) {
+    if (cpu_measurement->samples == 0) {
         return -1;
     }
 
-    measurement->mean = sum / (double)measurement->samples;
+    cpu_measurement->mean = cpu_sum / (double)cpu_measurement->samples;
+    if (gpu_measurement->samples > 0) {
+        gpu_measurement->mean = gpu_sum / (double)gpu_measurement->samples;
+        *gpu_available = 1;
+    }
     return 0;
 }
 
@@ -196,12 +295,22 @@ int main(void) {
         fclose(fp);
     }
 
-    struct CpuMeasurement cpu_measurement;
-    if (measure_cpu_usage(&cpu_measurement) == 0) {
+    struct LoadMeasurement cpu_measurement;
+    struct LoadMeasurement gpu_measurement;
+    int gpu_available;
+
+    if (measure_load(&cpu_measurement, &gpu_measurement, &gpu_available) == 0) {
         printf("CPU Utilization (5 sec): mean %.1f%% / min %.1f%% / max %.1f%%\n",
                cpu_measurement.mean, cpu_measurement.min, cpu_measurement.max);
+        if (gpu_available) {
+            printf("GPU Utilization (5 sec): mean %.1f%% / min %.1f%% / max %.1f%%\n",
+                   gpu_measurement.mean, gpu_measurement.min, gpu_measurement.max);
+        } else {
+            printf("GPU Utilization (5 sec): N/A\n");
+        }
     } else {
         printf("CPU Utilization (5 sec): N/A\n");
+        printf("GPU Utilization (5 sec): N/A\n");
     }
 
     now = time(NULL);


### PR DESCRIPTION
### Motivation
- Provide a more meaningful CPU measurement by sampling over a 5 second window and reporting aggregate stats instead of a single quick sample. 
- Give the user feedback during the measurement by printing progress updates at 10% increments.

### Description
- Replace the ad-hoc two-sample CPU check with structured types `struct CpuTimes` and `struct CpuMeasurement` and a new `measure_cpu_usage` routine that computes mean/min/max across samples. 
- Implement 10 evenly spaced samples (0.5s apart) for a 5 second measurement and print `"Measuring CPU utilization for 5 seconds..."` plus `"Measurement progress: %d%%"` each 10% step. 
- Add `sleep_interval` which wraps `nanosleep` with `EINTR` handling and add `cpu_usage_between` to compute utilization deltas robustly from `/proc/stat`. 
- Make the battery helper file-local by marking `get_battery_charge` as `static` and add `#include <errno.h>` for the new sleep/error handling.

### Testing
- Ran `make clean all` from the repo root and the project compiled successfully with no build errors. 
- Executed `./apps/stats` and observed progress lines at 10% increments during the 5s measurement and a final `CPU Utilization (5 sec): mean ... / min ... / max ...` line, confirming the new behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2859440744832782279a77bbee36e8)