### PR TITLE
Limit prompt path to 30% of terminal width

### DIFF
--- a/main.c
+++ b/main.c
@@ -412,7 +412,7 @@ static void format_prompt(char *prompt, size_t prompt_size) {
         return;
     }
 
-    max_path_width = (size_t)terminal_width_columns() / 2u;
+    max_path_width = ((size_t)terminal_width_columns() * 3u) / 10u;
     if (getcwd(cwd, sizeof(cwd)) != NULL) {
         truncate_path_for_prompt(cwd, display_path, sizeof(display_path), max_path_width);
         snprintf(prompt, prompt_size, "%s$ ", display_path);


### PR DESCRIPTION
### Motivation
- Reduce the width reserved for the displayed path in the prompt so the command-entry area is more usable by changing the cap from 50% to 30% of the terminal width.

### Description
- Adjusted prompt layout in `main.c` by changing `max_path_width` calculation in `format_prompt` to use 30% of `terminal_width_columns()` (`* 3 / 10`) instead of dividing by 2.

### Testing
- Ran `make clean all` from the repo root and the project built successfully with no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29bbfd4d0883279b831eccff926049)