### PR TITLE
Document missing TASK commands

### DIFF
--- a/commands/manual.txt
+++ b/commands/manual.txt
@@ -194,6 +194,20 @@ _TERM_ACTIVE
   Examples:
     _TERM_ACTIVE
 
+_TERM_BACKGROUND_SOUND
+  Syntax: _TERM_BACKGROUND_SOUND <enable|disable>
+  Use: Enable or disable the continuous terminal background hum.
+  Examples:
+    _TERM_BACKGROUND_SOUND enable
+    _TERM_BACKGROUND_SOUND disable
+
+_TERM_BACKGROUND_VOLUME
+  Syntax: _TERM_BACKGROUND_VOLUME <0-100>
+  Use: Set the continuous terminal background hum volume.
+  Examples:
+    _TERM_BACKGROUND_VOLUME 0
+    _TERM_BACKGROUND_VOLUME 70
+
 _TERM_CLEAN
   Syntax: _TERM_CLEAN -x <pixels> -y <pixels> -width <pixels>
           -height <pixels> [-layer <1-16>]
@@ -345,6 +359,13 @@ _TERM_TYPING_SOUND
   Examples:
     _TERM_TYPING_SOUND enable
     _TERM_TYPING_SOUND disable
+
+_TERM_TYPING_VOLUME
+  Syntax: _TERM_TYPING_VOLUME <0-100>
+  Use: Set keyboard typing sound effect volume in terminal apps.
+  Examples:
+    _TERM_TYPING_VOLUME 0
+    _TERM_TYPING_VOLUME 80
 
 _TEST
   Syntax: _TEST

--- a/documents/help.txt
+++ b/documents/help.txt
@@ -247,10 +247,16 @@
   _RETROPROFILE        : List/show/apply/reset retro color profiles.
   _STRCMP              : Compare strings with optional case sensitivity
                          and full-word matching.
+  _TERM_ACTIVE         : Print 1 in apps/terminal, else 0.
+  _TERM_BACKGROUND_SOUND
+                       : Enable or disable continuous terminal
+                         background hum.
+  _TERM_BACKGROUND_VOLUME
+                       : Set continuous terminal background hum volume
+                         0-100.
   _TERM_CLEAN          : Clear pixel rectangle area from terminal
                          render layer.
   _TERM_CURSOR_BLINK   : Enable or disable blinking cursor in terminal.
-  _TERM_ACTIVE         : Print 1 in apps/terminal, else 0.
   _TERM_KEYBOARD       : Read buffered key events as TASK array literal.
   _TERM_MARGIN         : Set terminal pixel render margin.
   _TERM_MOUSE          : Read mouse X/Y and left/right button counters.
@@ -272,6 +278,7 @@
   _TERM_SPRITE_LOAD    : Load sprite and output reusable TASK sprite literal.
   _TERM_TEXT           : Draw UTF-8 text in pixel space with color and layer.
   _TERM_TYPING_SOUND   : Enable or disable keyboard typing sound effects.
+  _TERM_TYPING_VOLUME  : Set keyboard typing sound effect volume 0-100.
   _TEST                : Print terminal diagnostic grid and size info.
   _TEXT                : Print text at column/row with optional color.
   _TIMER               : Start/stop/get/reset stopwatch in milliseconds.


### PR DESCRIPTION
### Motivation
- Ensure every executable in `./commands/` is listed and documented in the public TASK command references so users can find usage and examples. 
- Three terminal sound-related commands were implemented but not referenced in the shipped docs, causing a coverage gap reported by the repository checks.

### Description
- Added `_TERM_BACKGROUND_SOUND` and `_TERM_BACKGROUND_VOLUME` entries into `documents/help.txt` with brief descriptions. 
- Added corresponding full manual sections (syntax, use, examples) for `_TERM_BACKGROUND_SOUND` and `_TERM_BACKGROUND_VOLUME` to `commands/manual.txt`. 
- Added `_TERM_TYPING_VOLUME` entry to `documents/help.txt` and its full manual section to `commands/manual.txt` with syntax, usage, and examples. 
- Committed the documentation updates so the TASK command list and manual now reference all commands under `commands/_*.c`.

### Testing
- Ran a Python coverage check that enumerates `commands/_*.c` and confirmed all `53` commands are referenced in both `documents/help.txt` and `commands/manual.txt`, which passed. 
- Built the project with `make clean all`, and the build completed successfully with no warnings or errors under the repository `-Wall -Wextra -Werror -Wpedantic` settings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2da6b21cec8327b30cd838bfca8829)