### PR TITLE
Revamp apps/stats into retro ASCII system monitor (TERM_RESOLUTION LOW)

### DIFF
--- a/apps/stats.c
+++ b/apps/stats.c
@@ -3,6 +3,7 @@
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -22,7 +23,6 @@
 #define STATS_MAX_PROCESSES 512
 #define STATS_CMD_WIDTH 27
 #define STATS_REFRESH_SECONDS 1
-#define STATS_FIXED_FRAME_ROWS 16
 
 struct cpu_times {
     unsigned long long user;
@@ -486,7 +486,7 @@ static void draw_snapshot(const struct system_snapshot *snapshot, int columns)
     {
         char line[256];
 
-        snprintf(line, sizeof(line), "MU/TH/UR 6000 SYSTEM MONITOR | GRID 80x45 | %s", time_buffer);
+        snprintf(line, sizeof(line), "MU/TH/UR 6000 SYSTEM MONITOR        %s", time_buffer);
         print_panel_line(columns, line);
     }
     print_rule(columns, '+', '-', '+');
@@ -498,7 +498,7 @@ static void draw_snapshot(const struct system_snapshot *snapshot, int columns)
     {
         char line[256];
 
-        snprintf(line, sizeof(line), "LOAD  1M %5.2f  5M %5.2f 15M %5.2f | UPTIME %-12s | TASKS %4d",
+        snprintf(line, sizeof(line), "LOAD %4.2f %4.2f %4.2f | UPTIME %-12s | PROC %-4d",
                  snapshot->loadavg[0], snapshot->loadavg[1], snapshot->loadavg[2],
                  uptime_buffer, snapshot->process_count);
         print_panel_line(columns, line);
@@ -519,24 +519,24 @@ static void draw_snapshot(const struct system_snapshot *snapshot, int columns)
         } else {
             snprintf(battery_text, sizeof(battery_text), "N/A");
         }
-        snprintf(line, sizeof(line), "TEMP %-8s | BAT %-4s | MEM %7lu/%-7lu MB | ROOT FREE %8lu MB",
+        snprintf(line, sizeof(line), "TEMP %s | BAT %s | MEM %lu/%lu MB | ROOT FREE %lu MB",
                  temp_text, battery_text,
                  (snapshot->mem_total_kb - snapshot->mem_available_kb) / 1024UL,
                  snapshot->mem_total_kb / 1024UL, snapshot->disk_free_kb / 1024UL);
         print_panel_line(columns, line);
     }
     print_rule(columns, '+', '-', '+');
-    print_panel_line(columns, "  PID S CPU-TICKS   RSS-MB   VSZ-MB  COMMAND");
+    print_panel_line(columns, "PID    S CPU-TICKS   RSS-MB   VSZ-MB  COMMAND");
     print_rule(columns, '+', '-', '+');
 
-    process_rows = rows - STATS_FIXED_FRAME_ROWS;
+    process_rows = rows - 15;
     for (index = 0; index < process_rows; index++) {
         if (index < snapshot->process_count) {
             const struct process_info *process = &snapshot->processes[index];
 
             char line[256];
 
-            snprintf(line, sizeof(line), "%5d %c %9llu %8lu %8lu  %-27.27s",
+            snprintf(line, sizeof(line), "%5d  %c %9llu %8lu %8lu  %-27.27s",
                      process->pid, process->state, process->cpu_ticks,
                      process->rss_kb / 1024UL, process->vmsize_kb / 1024UL,
                      process->command);
@@ -546,7 +546,7 @@ static void draw_snapshot(const struct system_snapshot *snapshot, int columns)
         }
     }
     print_rule(columns, '+', '-', '+');
-    print_panel_line(columns, "[Q] QUIT  [R] REDRAW  [AUTO] 1 SECOND REFRESH  [MODE] _TERM_RESOLUTION LOW");
+    print_panel_line(columns, "[Q] QUIT  [R] REDRAW  [1s] AUTO-REFRESH  DISPLAY: _TERM_RESOLUTION LOW");
     print_rule(columns, '+', '=', '+');
     fflush(stdout);
 }

--- a/apps/stats.c
+++ b/apps/stats.c
@@ -3,7 +3,6 @@
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
-#include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -23,6 +22,7 @@
 #define STATS_MAX_PROCESSES 512
 #define STATS_CMD_WIDTH 27
 #define STATS_REFRESH_SECONDS 1
+#define STATS_FIXED_FRAME_ROWS 16
 
 struct cpu_times {
     unsigned long long user;
@@ -486,7 +486,7 @@ static void draw_snapshot(const struct system_snapshot *snapshot, int columns)
     {
         char line[256];
 
-        snprintf(line, sizeof(line), "MU/TH/UR 6000 SYSTEM MONITOR        %s", time_buffer);
+        snprintf(line, sizeof(line), "MU/TH/UR 6000 SYSTEM MONITOR | GRID 80x45 | %s", time_buffer);
         print_panel_line(columns, line);
     }
     print_rule(columns, '+', '-', '+');
@@ -498,7 +498,7 @@ static void draw_snapshot(const struct system_snapshot *snapshot, int columns)
     {
         char line[256];
 
-        snprintf(line, sizeof(line), "LOAD %4.2f %4.2f %4.2f | UPTIME %-12s | PROC %-4d",
+        snprintf(line, sizeof(line), "LOAD  1M %5.2f  5M %5.2f 15M %5.2f | UPTIME %-12s | TASKS %4d",
                  snapshot->loadavg[0], snapshot->loadavg[1], snapshot->loadavg[2],
                  uptime_buffer, snapshot->process_count);
         print_panel_line(columns, line);
@@ -519,24 +519,24 @@ static void draw_snapshot(const struct system_snapshot *snapshot, int columns)
         } else {
             snprintf(battery_text, sizeof(battery_text), "N/A");
         }
-        snprintf(line, sizeof(line), "TEMP %s | BAT %s | MEM %lu/%lu MB | ROOT FREE %lu MB",
+        snprintf(line, sizeof(line), "TEMP %-8s | BAT %-4s | MEM %7lu/%-7lu MB | ROOT FREE %8lu MB",
                  temp_text, battery_text,
                  (snapshot->mem_total_kb - snapshot->mem_available_kb) / 1024UL,
                  snapshot->mem_total_kb / 1024UL, snapshot->disk_free_kb / 1024UL);
         print_panel_line(columns, line);
     }
     print_rule(columns, '+', '-', '+');
-    print_panel_line(columns, "PID    S CPU-TICKS   RSS-MB   VSZ-MB  COMMAND");
+    print_panel_line(columns, "  PID S CPU-TICKS   RSS-MB   VSZ-MB  COMMAND");
     print_rule(columns, '+', '-', '+');
 
-    process_rows = rows - 15;
+    process_rows = rows - STATS_FIXED_FRAME_ROWS;
     for (index = 0; index < process_rows; index++) {
         if (index < snapshot->process_count) {
             const struct process_info *process = &snapshot->processes[index];
 
             char line[256];
 
-            snprintf(line, sizeof(line), "%5d  %c %9llu %8lu %8lu  %-27.27s",
+            snprintf(line, sizeof(line), "%5d %c %9llu %8lu %8lu  %-27.27s",
                      process->pid, process->state, process->cpu_ticks,
                      process->rss_kb / 1024UL, process->vmsize_kb / 1024UL,
                      process->command);
@@ -546,7 +546,7 @@ static void draw_snapshot(const struct system_snapshot *snapshot, int columns)
         }
     }
     print_rule(columns, '+', '-', '+');
-    print_panel_line(columns, "[Q] QUIT  [R] REDRAW  [1s] AUTO-REFRESH  DISPLAY: _TERM_RESOLUTION LOW");
+    print_panel_line(columns, "[Q] QUIT  [R] REDRAW  [AUTO] 1 SECOND REFRESH  [MODE] _TERM_RESOLUTION LOW");
     print_rule(columns, '+', '=', '+');
     fflush(stdout);
 }

--- a/apps/stats.c
+++ b/apps/stats.c
@@ -1,59 +1,30 @@
 #define _POSIX_C_SOURCE 200809L
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
-#include <sys/statvfs.h>
-#include <unistd.h>
+#include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/ioctl.h>
+#include <sys/select.h>
+#include <sys/statvfs.h>
+#include <sys/types.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
 
-// Function to get battery charge (if available)
-// Returns battery capacity (0–100) if found, or -1 if no battery is found.
-static int get_battery_charge(void) {
-    DIR *dir = opendir("/sys/class/power_supply");
-    if (!dir) {
-        return -1;
-    }
+#define STATS_MIN_COLUMNS 60
+#define STATS_LOW_COLUMNS 80
+#define STATS_LOW_ROWS 45
+#define STATS_BAR_WIDTH 24
+#define STATS_MAX_PROCESSES 512
+#define STATS_CMD_WIDTH 27
+#define STATS_REFRESH_SECONDS 1
 
-    struct dirent *entry;
-    char type_path[512];
-    char capacity_path[512];
-    char type_str[64];
-    int battery = -1;
-
-    while ((entry = readdir(dir)) != NULL) {
-        if (entry->d_name[0] == '.')
-            continue;
-        snprintf(type_path, sizeof(type_path), "/sys/class/power_supply/%s/type", entry->d_name);
-        FILE *fp = fopen(type_path, "r");
-        if (!fp)
-            continue;
-        if (fgets(type_str, sizeof(type_str), fp) != NULL) {
-            type_str[strcspn(type_str, "\n")] = '\0';
-            if (strcmp(type_str, "Battery") == 0) {
-                fclose(fp);
-                snprintf(capacity_path, sizeof(capacity_path), "/sys/class/power_supply/%s/capacity", entry->d_name);
-                fp = fopen(capacity_path, "r");
-                if (fp) {
-                    if (fscanf(fp, "%d", &battery) != 1)
-                        battery = -1;
-                    fclose(fp);
-                    break; // Use the first battery found
-                }
-            } else {
-                fclose(fp);
-            }
-        } else {
-            fclose(fp);
-        }
-    }
-    closedir(dir);
-    return battery;
-}
-
-struct CpuTimes {
+struct cpu_times {
     unsigned long long user;
     unsigned long long nice;
     unsigned long long system;
@@ -64,211 +35,582 @@ struct CpuTimes {
     unsigned long long steal;
 };
 
-struct CpuMeasurement {
-    double mean;
-    double min;
-    double max;
-    int samples;
+struct process_info {
+    int pid;
+    char state;
+    unsigned long vmsize_kb;
+    unsigned long rss_kb;
+    unsigned long long cpu_ticks;
+    char command[STATS_CMD_WIDTH + 1];
 };
 
-static int read_cpu_stats(struct CpuTimes *stats) {
+struct system_snapshot {
+    struct cpu_times cpu;
+    double cpu_percent;
+    unsigned long mem_total_kb;
+    unsigned long mem_available_kb;
+    unsigned long swap_total_kb;
+    unsigned long swap_free_kb;
+    unsigned long disk_total_kb;
+    unsigned long disk_free_kb;
+    double uptime_seconds;
+    double loadavg[3];
+    int battery_percent;
+    int cpu_temp_millic;
+    int process_count;
+    struct process_info processes[STATS_MAX_PROCESSES];
+};
+
+static struct termios saved_termios;
+static int terminal_restored = 1;
+
+static void restore_terminal(void)
+{
+    if (!terminal_restored) {
+        tcsetattr(STDIN_FILENO, TCSAFLUSH, &saved_termios);
+        printf("\033[?25h\033[0m\033[2J\033[H");
+        fflush(stdout);
+        terminal_restored = 1;
+    }
+}
+
+static int enter_terminal(void)
+{
+    struct termios raw;
+
+    if (tcgetattr(STDIN_FILENO, &saved_termios) != 0) {
+        return -1;
+    }
+    raw = saved_termios;
+    raw.c_lflag &= (tcflag_t)~(ICANON | ECHO);
+    raw.c_cc[VMIN] = 0;
+    raw.c_cc[VTIME] = 0;
+    if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw) != 0) {
+        return -1;
+    }
+    terminal_restored = 0;
+    atexit(restore_terminal);
+    printf("\033[?25l\033[2J\033[H");
+    fflush(stdout);
+    return 0;
+}
+
+static void handle_signal(int signal_number)
+{
+    (void)signal_number;
+    restore_terminal();
+    _exit(EXIT_FAILURE);
+}
+
+static unsigned long long cpu_total(const struct cpu_times *cpu)
+{
+    return cpu->user + cpu->nice + cpu->system + cpu->idle + cpu->iowait +
+           cpu->irq + cpu->softirq + cpu->steal;
+}
+
+static unsigned long long cpu_idle(const struct cpu_times *cpu)
+{
+    return cpu->idle + cpu->iowait;
+}
+
+static int read_cpu_times(struct cpu_times *cpu)
+{
     FILE *fp = fopen("/proc/stat", "r");
+    int read_count;
+
     if (!fp) {
         return -1;
     }
-
-    int ret = fscanf(fp, "cpu  %llu %llu %llu %llu %llu %llu %llu %llu",
-                     &stats->user, &stats->nice, &stats->system, &stats->idle,
-                     &stats->iowait, &stats->irq, &stats->softirq, &stats->steal);
+    read_count = fscanf(fp, "cpu %llu %llu %llu %llu %llu %llu %llu %llu",
+                        &cpu->user, &cpu->nice, &cpu->system, &cpu->idle,
+                        &cpu->iowait, &cpu->irq, &cpu->softirq, &cpu->steal);
     fclose(fp);
-    return (ret == 8) ? 0 : -1;
+    return read_count == 8 ? 0 : -1;
 }
 
-static void sleep_interval(long nanoseconds) {
-    struct timespec remaining;
-    struct timespec request;
+static double cpu_percent_between(const struct cpu_times *before,
+                                  const struct cpu_times *after)
+{
+    unsigned long long total_before = cpu_total(before);
+    unsigned long long total_after = cpu_total(after);
+    unsigned long long idle_before = cpu_idle(before);
+    unsigned long long idle_after = cpu_idle(after);
+    unsigned long long total_delta = total_after - total_before;
+    unsigned long long idle_delta = idle_after - idle_before;
 
-    request.tv_sec = nanoseconds / 1000000000L;
-    request.tv_nsec = nanoseconds % 1000000000L;
-
-    while (nanosleep(&request, &remaining) == -1) {
-        if (errno != EINTR) {
-            return;
-        }
-        request = remaining;
+    if (total_delta == 0 || idle_delta > total_delta) {
+        return 0.0;
     }
+    return (double)(total_delta - idle_delta) * 100.0 / (double)total_delta;
 }
 
-static int cpu_usage_between(const struct CpuTimes *before,
-                             const struct CpuTimes *after,
-                             double *usage) {
-    unsigned long long total_before = before->user + before->nice + before->system +
-                                      before->idle + before->iowait + before->irq +
-                                      before->softirq + before->steal;
-    unsigned long long total_after = after->user + after->nice + after->system +
-                                     after->idle + after->iowait + after->irq +
-                                     after->softirq + after->steal;
-    unsigned long long idle_before = before->idle + before->iowait;
-    unsigned long long idle_after = after->idle + after->iowait;
-    unsigned long long delta_total = total_after - total_before;
-    unsigned long long delta_idle = idle_after - idle_before;
+static void read_meminfo(struct system_snapshot *snapshot)
+{
+    FILE *fp = fopen("/proc/meminfo", "r");
+    char line[256];
 
-    if (delta_total == 0 || delta_total < delta_idle) {
-        return -1;
+    if (!fp) {
+        return;
     }
-
-    *usage = (double)(delta_total - delta_idle) * 100.0 / (double)delta_total;
-    return 0;
+    while (fgets(line, sizeof(line), fp)) {
+        sscanf(line, "MemTotal: %lu kB", &snapshot->mem_total_kb);
+        sscanf(line, "MemAvailable: %lu kB", &snapshot->mem_available_kb);
+        sscanf(line, "SwapTotal: %lu kB", &snapshot->swap_total_kb);
+        sscanf(line, "SwapFree: %lu kB", &snapshot->swap_free_kb);
+    }
+    fclose(fp);
 }
 
-static int measure_cpu_usage(struct CpuMeasurement *measurement) {
-    enum {
-        sample_count = 10
-    };
-    const long sample_interval_ns = 500000000L;
-    struct CpuTimes before;
-    double sum = 0.0;
+static void read_uptime(struct system_snapshot *snapshot)
+{
+    FILE *fp = fopen("/proc/uptime", "r");
 
-    measurement->mean = 0.0;
-    measurement->min = 0.0;
-    measurement->max = 0.0;
-    measurement->samples = 0;
-
-    if (read_cpu_stats(&before) != 0) {
-        return -1;
+    if (!fp) {
+        return;
     }
-
-    printf("Measuring CPU utilization for 5 seconds...\n");
-    for (int sample = 1; sample <= sample_count; sample++) {
-        struct CpuTimes after;
-        double usage;
-
-        sleep_interval(sample_interval_ns);
-        if (read_cpu_stats(&after) != 0) {
-            return -1;
-        }
-        if (cpu_usage_between(&before, &after, &usage) == 0) {
-            if (measurement->samples == 0 || usage < measurement->min) {
-                measurement->min = usage;
-            }
-            if (measurement->samples == 0 || usage > measurement->max) {
-                measurement->max = usage;
-            }
-            sum += usage;
-            measurement->samples++;
-        }
-        before = after;
-        printf("Measurement progress: %d%%\n", sample * 10);
-        fflush(stdout);
+    if (fscanf(fp, "%lf", &snapshot->uptime_seconds) != 1) {
+        snapshot->uptime_seconds = 0.0;
     }
-
-    if (measurement->samples == 0) {
-        return -1;
-    }
-
-    measurement->mean = sum / (double)measurement->samples;
-    return 0;
+    fclose(fp);
 }
 
-int main(void) {
-    time_t start_time = time(NULL);
-    time_t now = start_time;
-    struct tm *local = localtime(&now);
-    char time_str[64];
-    if (local && strftime(time_str, sizeof(time_str), "%H:%M:%S %d-%B-%Y", local)) {
-        printf("Time: %s\n", time_str);
-    }
+static void read_loadavg(struct system_snapshot *snapshot)
+{
+    FILE *fp = fopen("/proc/loadavg", "r");
 
+    if (!fp) {
+        return;
+    }
+    if (fscanf(fp, "%lf %lf %lf", &snapshot->loadavg[0], &snapshot->loadavg[1],
+               &snapshot->loadavg[2]) != 3) {
+        snapshot->loadavg[0] = 0.0;
+        snapshot->loadavg[1] = 0.0;
+        snapshot->loadavg[2] = 0.0;
+    }
+    fclose(fp);
+}
+
+static void read_disk(struct system_snapshot *snapshot)
+{
     struct statvfs stat;
+
     if (statvfs("/", &stat) == 0) {
-        unsigned long free_bytes = stat.f_bfree * stat.f_frsize;
-        double free_gb = free_bytes / (1024.0 * 1024.0 * 1024.0);
-        printf("Free Disk Space: %.1fGB\n", free_gb);
+        snapshot->disk_total_kb = (unsigned long)((stat.f_blocks * stat.f_frsize) / 1024UL);
+        snapshot->disk_free_kb = (unsigned long)((stat.f_bavail * stat.f_frsize) / 1024UL);
     }
+}
 
+static int read_battery(void)
+{
+    DIR *dir = opendir("/sys/class/power_supply");
+    struct dirent *entry;
+    int battery = -1;
+
+    if (!dir) {
+        return -1;
+    }
+    while ((entry = readdir(dir)) != NULL) {
+        char path[512];
+        char type[64];
+        FILE *fp;
+
+        if (entry->d_name[0] == '.') {
+            continue;
+        }
+        snprintf(path, sizeof(path), "/sys/class/power_supply/%s/type", entry->d_name);
+        fp = fopen(path, "r");
+        if (!fp) {
+            continue;
+        }
+        if (fgets(type, sizeof(type), fp) && strncmp(type, "Battery", 7) == 0) {
+            fclose(fp);
+            snprintf(path, sizeof(path), "/sys/class/power_supply/%s/capacity", entry->d_name);
+            fp = fopen(path, "r");
+            if (fp) {
+                if (fscanf(fp, "%d", &battery) != 1) {
+                    battery = -1;
+                }
+                fclose(fp);
+            }
+            break;
+        }
+        fclose(fp);
+    }
+    closedir(dir);
+    return battery;
+}
+
+static int read_cpu_temp(void)
+{
     FILE *fp = fopen("/sys/class/thermal/thermal_zone0/temp", "r");
+    int temp = -1;
+
     if (fp) {
-        int temp_millideg;
-        if (fscanf(fp, "%d", &temp_millideg) == 1) {
-            double cpu_temp = temp_millideg / 1000.0;
-            printf("CPU Temp: %.0f°C\n", cpu_temp);
+        if (fscanf(fp, "%d", &temp) != 1) {
+            temp = -1;
         }
         fclose(fp);
     }
+    return temp;
+}
 
-    struct CpuMeasurement cpu_measurement;
-    if (measure_cpu_usage(&cpu_measurement) == 0) {
-        printf("CPU Utilization (5 sec): mean %.1f%% / min %.1f%% / max %.1f%%\n",
-               cpu_measurement.mean, cpu_measurement.min, cpu_measurement.max);
+static int parse_process_stat(int pid, struct process_info *process)
+{
+    char path[64];
+    char line[1024];
+    char *open_paren;
+    char *close_paren;
+    char *cursor;
+    FILE *fp;
+    unsigned long utime = 0UL;
+    unsigned long stime = 0UL;
+    long rss_pages = 0L;
+    int field = 4;
+
+    snprintf(path, sizeof(path), "/proc/%d/stat", pid);
+    fp = fopen(path, "r");
+    if (!fp) {
+        return -1;
+    }
+    if (!fgets(line, sizeof(line), fp)) {
+        fclose(fp);
+        return -1;
+    }
+    fclose(fp);
+
+    open_paren = strchr(line, '(');
+    close_paren = strrchr(line, ')');
+    if (!open_paren || !close_paren || close_paren <= open_paren) {
+        return -1;
+    }
+    *close_paren = '\0';
+    snprintf(process->command, sizeof(process->command), "%s", open_paren + 1);
+    cursor = close_paren + 2;
+    process->state = *cursor;
+    cursor += 2;
+
+    while (*cursor != '\0') {
+        char *end;
+        unsigned long long value = strtoull(cursor, &end, 10);
+
+        if (end == cursor) {
+            break;
+        }
+        if (field == 14) {
+            utime = (unsigned long)value;
+        } else if (field == 15) {
+            stime = (unsigned long)value;
+        } else if (field == 23) {
+            process->vmsize_kb = (unsigned long)(value / 1024ULL);
+        } else if (field == 24) {
+            rss_pages = (long)value;
+            break;
+        }
+        field++;
+        cursor = end;
+        while (*cursor == ' ') {
+            cursor++;
+        }
+    }
+    process->pid = pid;
+    process->cpu_ticks = (unsigned long long)utime + (unsigned long long)stime;
+    process->rss_kb = rss_pages > 0 ? (unsigned long)rss_pages * (unsigned long)(sysconf(_SC_PAGESIZE) / 1024L) : 0UL;
+    return 0;
+}
+
+static int compare_processes(const void *left, const void *right)
+{
+    const struct process_info *a = (const struct process_info *)left;
+    const struct process_info *b = (const struct process_info *)right;
+
+    if (a->cpu_ticks < b->cpu_ticks) {
+        return 1;
+    }
+    if (a->cpu_ticks > b->cpu_ticks) {
+        return -1;
+    }
+    if (a->rss_kb < b->rss_kb) {
+        return 1;
+    }
+    if (a->rss_kb > b->rss_kb) {
+        return -1;
+    }
+    return a->pid - b->pid;
+}
+
+static void read_processes(struct system_snapshot *snapshot)
+{
+    DIR *dir = opendir("/proc");
+    struct dirent *entry;
+
+    if (!dir) {
+        return;
+    }
+    while ((entry = readdir(dir)) != NULL && snapshot->process_count < STATS_MAX_PROCESSES) {
+        int pid = 0;
+        const char *name = entry->d_name;
+
+        while (*name) {
+            if (!isdigit((unsigned char)*name)) {
+                pid = -1;
+                break;
+            }
+            pid = (pid * 10) + (*name - '0');
+            name++;
+        }
+        if (pid > 0 && parse_process_stat(pid, &snapshot->processes[snapshot->process_count]) == 0) {
+            snapshot->process_count++;
+        }
+    }
+    closedir(dir);
+    qsort(snapshot->processes, (size_t)snapshot->process_count,
+          sizeof(snapshot->processes[0]), compare_processes);
+}
+
+static void read_snapshot(struct system_snapshot *snapshot,
+                          const struct cpu_times *previous_cpu)
+{
+    memset(snapshot, 0, sizeof(*snapshot));
+    snapshot->battery_percent = -1;
+    snapshot->cpu_temp_millic = -1;
+    if (read_cpu_times(&snapshot->cpu) == 0 && previous_cpu) {
+        snapshot->cpu_percent = cpu_percent_between(previous_cpu, &snapshot->cpu);
+    }
+    read_meminfo(snapshot);
+    read_uptime(snapshot);
+    read_loadavg(snapshot);
+    read_disk(snapshot);
+    snapshot->battery_percent = read_battery();
+    snapshot->cpu_temp_millic = read_cpu_temp();
+    read_processes(snapshot);
+}
+
+static void format_duration(double seconds, char *buffer, size_t size)
+{
+    int total = (int)seconds;
+    int days = total / 86400;
+    int hours = (total % 86400) / 3600;
+    int minutes = (total % 3600) / 60;
+
+    if (days > 0) {
+        snprintf(buffer, size, "%dd %02dh %02dm", days, hours, minutes);
     } else {
-        printf("CPU Utilization (5 sec): N/A\n");
+        snprintf(buffer, size, "%02dh %02dm", hours, minutes);
     }
+}
 
-    now = time(NULL);
-    double elapsed = difftime(now, start_time);
-    int hrs = (int)elapsed / 3600;
-    int mins = ((int)elapsed % 3600) / 60;
-    int secs = (int)elapsed % 60;
-    printf("Runtime: %02d:%02d:%02d\n", hrs, mins, secs);
+static void print_rule(int columns, char left, char fill, char right)
+{
+    int index;
 
-    fp = fopen("/proc/uptime", "r");
-    if (fp) {
-        double uptime_seconds;
-        if (fscanf(fp, "%lf", &uptime_seconds) == 1) {
-            int days = (int)uptime_seconds / (24 * 3600);
-            int hours = ((int)uptime_seconds % (24 * 3600)) / 3600;
-            int minutes = (((int)uptime_seconds % 3600)) / 60;
-            int seconds = (int)uptime_seconds % 60;
-            printf("Uptime: ");
-            int printed = 0;
-            if (days > 0) {
-                printf("%d %s", days, (days == 1 ? "day" : "days"));
-                printed = 1;
-            }
-            if (hours > 0) {
-                if (printed)
-                    printf(" ");
-                printf("%d %s", hours, (hours == 1 ? "hour" : "hours"));
-                printed = 1;
-            }
-            if (minutes > 0) {
-                if (printed)
-                    printf(" ");
-                printf("%d %s", minutes, (minutes == 1 ? "minute" : "minutes"));
-                printed = 1;
-            }
-            if (printed)
-                printf(" and ");
-            printf("%d %s\n", seconds, (seconds == 1 ? "second" : "seconds"));
+    putchar(left);
+    for (index = 0; index < columns - 2; index++) {
+        putchar(fill);
+    }
+    putchar(right);
+    putchar('\n');
+}
+
+static void print_panel_line(int columns, const char *text)
+{
+    int content_width = columns - 4;
+
+    if (content_width < 1) {
+        content_width = STATS_LOW_COLUMNS - 4;
+    }
+    printf("| %-*.*s |\n", content_width, content_width, text);
+}
+
+static void print_bar(const char *label, double percent, int width, int columns)
+{
+    int filled;
+    int index;
+
+    if (percent < 0.0) {
+        percent = 0.0;
+    } else if (percent > 100.0) {
+        percent = 100.0;
+    }
+    filled = (int)((percent * (double)width) / 100.0 + 0.5);
+    char line[256];
+    char bar[STATS_BAR_WIDTH + 1];
+
+    for (index = 0; index < width; index++) {
+        if (index < filled) {
+            bar[index] = index % 2 == 0 ? '#' : '=';
+        } else if (index == filled) {
+            bar[index] = '>';
+        } else {
+            bar[index] = '.';
         }
-        fclose(fp);
+    }
+    bar[width] = '\0';
+    snprintf(line, sizeof(line), "%-5s [%s] %5.1f%%", label, bar, percent);
+    print_panel_line(columns, line);
+}
+
+static void draw_snapshot(const struct system_snapshot *snapshot, int columns)
+{
+    char time_buffer[64];
+    char uptime_buffer[32];
+    time_t now = time(NULL);
+    struct tm local_time;
+    double mem_percent = 0.0;
+    double swap_percent = 0.0;
+    double disk_percent = 0.0;
+    int rows = STATS_LOW_ROWS;
+    int process_rows;
+    int index;
+
+    if (columns < STATS_MIN_COLUMNS) {
+        columns = STATS_LOW_COLUMNS;
+    }
+    localtime_r(&now, &local_time);
+    strftime(time_buffer, sizeof(time_buffer), "%H:%M:%S  %d-%b-%Y", &local_time);
+    format_duration(snapshot->uptime_seconds, uptime_buffer, sizeof(uptime_buffer));
+    if (snapshot->mem_total_kb > 0UL) {
+        mem_percent = (double)(snapshot->mem_total_kb - snapshot->mem_available_kb) * 100.0 /
+                      (double)snapshot->mem_total_kb;
+    }
+    if (snapshot->swap_total_kb > 0UL) {
+        swap_percent = (double)(snapshot->swap_total_kb - snapshot->swap_free_kb) * 100.0 /
+                       (double)snapshot->swap_total_kb;
+    }
+    if (snapshot->disk_total_kb > 0UL) {
+        disk_percent = (double)(snapshot->disk_total_kb - snapshot->disk_free_kb) * 100.0 /
+                       (double)snapshot->disk_total_kb;
     }
 
-    fp = fopen("/proc/meminfo", "r");
-    if (fp) {
+    printf("\033[H");
+    print_rule(columns, '+', '=', '+');
+    {
         char line[256];
-        unsigned long memTotal = 0, memAvailable = 0;
-        while (fgets(line, sizeof(line), fp)) {
-            if (sscanf(line, "MemTotal: %lu kB", &memTotal) == 1)
-                continue;
-            if (sscanf(line, "MemAvailable: %lu kB", &memAvailable) == 1)
-                continue;
+
+        snprintf(line, sizeof(line), "MU/TH/UR 6000 SYSTEM MONITOR        %s", time_buffer);
+        print_panel_line(columns, line);
+    }
+    print_rule(columns, '+', '-', '+');
+    print_bar("CPU", snapshot->cpu_percent, STATS_BAR_WIDTH, columns);
+    print_bar("MEM", mem_percent, STATS_BAR_WIDTH, columns);
+    print_bar("SWAP", swap_percent, STATS_BAR_WIDTH, columns);
+    print_bar("DISK", disk_percent, STATS_BAR_WIDTH, columns);
+    print_rule(columns, '+', '-', '+');
+    {
+        char line[256];
+
+        snprintf(line, sizeof(line), "LOAD %4.2f %4.2f %4.2f | UPTIME %-12s | PROC %-4d",
+                 snapshot->loadavg[0], snapshot->loadavg[1], snapshot->loadavg[2],
+                 uptime_buffer, snapshot->process_count);
+        print_panel_line(columns, line);
+    }
+    {
+        char line[256];
+        char temp_text[32];
+        char battery_text[16];
+
+        if (snapshot->cpu_temp_millic >= 0) {
+            snprintf(temp_text, sizeof(temp_text), "%5.1f C",
+                     (double)snapshot->cpu_temp_millic / 1000.0);
+        } else {
+            snprintf(temp_text, sizeof(temp_text), "N/A");
         }
-        fclose(fp);
-        if (memTotal > 0) {
-            double totalMB = memTotal / 1024.0;
-            double usedMB = (memTotal - memAvailable) / 1024.0;
-            double usedPercent = ((memTotal - memAvailable) * 100.0) / memTotal;
-            printf("Memory Usage: %.1fMB used / %.1fMB total (%.1f%%)\n", usedMB, totalMB, usedPercent);
+        if (snapshot->battery_percent >= 0) {
+            snprintf(battery_text, sizeof(battery_text), "%3d%%", snapshot->battery_percent);
+        } else {
+            snprintf(battery_text, sizeof(battery_text), "N/A");
+        }
+        snprintf(line, sizeof(line), "TEMP %s | BAT %s | MEM %lu/%lu MB | ROOT FREE %lu MB",
+                 temp_text, battery_text,
+                 (snapshot->mem_total_kb - snapshot->mem_available_kb) / 1024UL,
+                 snapshot->mem_total_kb / 1024UL, snapshot->disk_free_kb / 1024UL);
+        print_panel_line(columns, line);
+    }
+    print_rule(columns, '+', '-', '+');
+    print_panel_line(columns, "PID    S CPU-TICKS   RSS-MB   VSZ-MB  COMMAND");
+    print_rule(columns, '+', '-', '+');
+
+    process_rows = rows - 15;
+    for (index = 0; index < process_rows; index++) {
+        if (index < snapshot->process_count) {
+            const struct process_info *process = &snapshot->processes[index];
+
+            char line[256];
+
+            snprintf(line, sizeof(line), "%5d  %c %9llu %8lu %8lu  %-27.27s",
+                     process->pid, process->state, process->cpu_ticks,
+                     process->rss_kb / 1024UL, process->vmsize_kb / 1024UL,
+                     process->command);
+            print_panel_line(columns, line);
+        } else {
+            print_panel_line(columns, "");
+        }
+    }
+    print_rule(columns, '+', '-', '+');
+    print_panel_line(columns, "[Q] QUIT  [R] REDRAW  [1s] AUTO-REFRESH  DISPLAY: _TERM_RESOLUTION LOW");
+    print_rule(columns, '+', '=', '+');
+    fflush(stdout);
+}
+
+static int terminal_columns(void)
+{
+    struct winsize size;
+
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &size) == 0 && size.ws_col > 0) {
+        return size.ws_col > STATS_LOW_COLUMNS ? STATS_LOW_COLUMNS : size.ws_col;
+    }
+    return STATS_LOW_COLUMNS;
+}
+
+static int wait_for_key_or_timeout(void)
+{
+    fd_set read_fds;
+    struct timeval timeout;
+    int result;
+
+    FD_ZERO(&read_fds);
+    FD_SET(STDIN_FILENO, &read_fds);
+    timeout.tv_sec = STATS_REFRESH_SECONDS;
+    timeout.tv_usec = 0;
+    result = select(STDIN_FILENO + 1, &read_fds, NULL, NULL, &timeout);
+    if (result > 0 && FD_ISSET(STDIN_FILENO, &read_fds)) {
+        unsigned char key;
+
+        if (read(STDIN_FILENO, &key, sizeof(key)) == 1) {
+            return key;
+        }
+    }
+    return 0;
+}
+
+int main(void)
+{
+    struct system_snapshot snapshot;
+    struct cpu_times previous_cpu;
+    int have_previous = 0;
+    int running = 1;
+
+    if (enter_terminal() != 0) {
+        perror("stats: terminal setup");
+        return EXIT_FAILURE;
+    }
+    signal(SIGINT, handle_signal);
+    signal(SIGTERM, handle_signal);
+
+    while (running) {
+        int key;
+
+        read_snapshot(&snapshot, have_previous ? &previous_cpu : NULL);
+        previous_cpu = snapshot.cpu;
+        have_previous = 1;
+        draw_snapshot(&snapshot, terminal_columns());
+        key = wait_for_key_or_timeout();
+        if (key == 'q' || key == 'Q') {
+            running = 0;
+        } else if (key == 'r' || key == 'R') {
+            printf("\033[2J");
         }
     }
 
-    int battery = get_battery_charge();
-    if (battery >= 0) {
-        printf("Battery Charge: %d%%\n", battery);
-    } else {
-        printf("Battery Charge: N/A\n");
-    }
-
+    restore_terminal();
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
### Motivation
- Replace the old one-shot textual stats app with a live interactive monitor tuned for `_TERM_RESOLUTION LOW` (80-column) terminals and a retro MU/TH/UR‑style panel look. 
- Provide a compact, information-dense view appropriate for low-resolution terminals including a top title panel, mid telemetry bars, a process table, and a bottom shortcut bar. 
- Make the utility usable as a terminal app by entering raw mode, hiding/restoring the cursor, and handling signals so it behaves cleanly in interactive sessions. 

### Description
- Reworked `apps/stats.c` into an interactive dashboard that enters raw terminal mode, installs `SIGINT`/`SIGTERM` handlers, and restores terminal state at exit. 
- Added structured snapshot collection and parsing functions for CPU, memory, swap, disk, load averages, uptime, battery, CPU temperature, and `/proc` process parsing and sorting. 
- Implemented ASCII layout helpers: `print_rule`, `print_panel_line`, `print_bar`, and `draw_snapshot` to render an 80-column MU/TH/UR-style interface with progress bars and a process table sized for `_TERM_RESOLUTION LOW`. 
- Added nonblocking input with a `select` timeout to support per-second refresh, and keyboard shortcuts shown in a bottom bar (`[Q] QUIT  [R] REDRAW  [1s] AUTO-REFRESH  DISPLAY: _TERM_RESOLUTION LOW`). 

### Testing
- Built the entire project with `make clean all` from the repo root and the build completed successfully with no warnings or errors. 
- Ran the monitor noninteractively to validate rendering with `printf q | script -q -c './apps/stats' /dev/null | head -n 50 | cat -v` which produced the expected 80‑column ASCII dashboard output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dad6888888327abe835caaf547bba)