### PR TITLE
Fix arrow key handling in editor search results

### DIFF
--- a/apps/edit.c
+++ b/apps/edit.c
@@ -1601,6 +1601,12 @@ int editorReadKey(void) {
             return '\x1b';
         if (seq[0] == 'O') {
             switch (seq[1]) {
+                case 'A': return ARROW_UP;
+                case 'B': return ARROW_DOWN;
+                case 'C': return ARROW_RIGHT;
+                case 'D': return ARROW_LEFT;
+                case 'H': return HOME_KEY;
+                case 'F': return END_KEY;
                 case 'P': return F1_KEY;
                 case 'Q': return F2_KEY;
                 case 'R': return F3_KEY;
@@ -1634,6 +1640,24 @@ int editorReadKey(void) {
             char seq2;
             if (read(STDIN_FILENO, &seq2, 1) != 1)
                 return '\x1b';
+            if (seq2 == ';') {
+                char modifier;
+                char final;
+                if (read(STDIN_FILENO, &modifier, 1) != 1)
+                    return '\x1b';
+                if (read(STDIN_FILENO, &final, 1) != 1)
+                    return '\x1b';
+                (void)modifier;
+                switch (final) {
+                    case 'A': return ARROW_UP;
+                    case 'B': return ARROW_DOWN;
+                    case 'C': return ARROW_RIGHT;
+                    case 'D': return ARROW_LEFT;
+                    case 'H': return HOME_KEY;
+                    case 'F': return END_KEY;
+                    default: return '\x1b';
+                }
+            }
             if (seq2 >= '0' && seq2 <= '9') {
                 char seq3;
                 if (read(STDIN_FILENO, &seq3, 1) != 1)


### PR DESCRIPTION
### Motivation
- The Find/search full-screen menu could not be navigated with Up/Down arrows because some terminals send SS3 (`ESC O ...`) or modified CSI sequences (`ESC [ ... ; <mod> <final>`) that were not decoded by the input parser.

### Description
- Update `editorReadKey` to decode SS3 sequences (`ESC O A/B/C/D/H/F`) and map them to `ARROW_*`, `HOME_KEY`, and `END_KEY`.
- Add parsing for modified CSI sequences where the second byte is `';'` (e.g. `ESC [ 1 ; 2 A`) to decode the final character and return the appropriate navigation key instead of discarding the sequence.
- Preserve existing bracketed paste handling and numeric-tilde (`~`) handlers; changes only extend decoding to additional common terminal sequences.

### Testing
- Ran `make clean all` which compiled the project and produced the binaries without warnings or errors (build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2db510786c8327ba102e06c151fb8b)